### PR TITLE
Potential fix for code scanning alert no. 11: Inefficient regular expression

### DIFF
--- a/e2e/tools-drawing.spec.ts
+++ b/e2e/tools-drawing.spec.ts
@@ -344,7 +344,7 @@ test.describe('Edge Cases', () => {
         await page.waitForTimeout(200);
         
         const ascii = await page.evaluate(() => (window as any).editor.exportAscii());
-        expect(ascii).not.toMatch(/^(\s*\n)*$/);
+        expect(ascii).not.toMatch(/^[ \t\r]*(?:\n[ \t\r]*)*$/);
         
         await page.screenshot({ path: 'test-results/edge-single-point.png' });
     });


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-ascii-canvas/security/code-scanning/11](https://github.com/d-o-hub/rust-ascii-canvas/security/code-scanning/11)

In general, to fix inefficient regular expressions with nested or ambiguous quantifiers, rewrite the pattern so that there are no overlapping ways to consume the same characters inside a repeated construct. Here, the intent is to match strings that consist only of blank or whitespace-only lines (possibly none). The current regex `/^(\s*\n)*$/` uses `\s*` (which can match `\n`) immediately followed by `\n`, all inside a `*` group, which is ambiguous.

The best minimal fix is to restrict the `\s*` so it cannot consume newline characters, and to handle an optional final line without a trailing newline, while still matching only whitespace. One efficient and clear pattern for “zero or more whitespace-only lines, each optionally ending with a newline” is:

```ts
/^[ \t\r]*(?:\n[ \t\r]*)*$/
```

This avoids nested ambiguity because `[ \t\r]*` excludes `\n`, so only the explicit `\n` can match newline characters. Functionally, this still matches strings composed solely of spaces, tabs, carriage returns, and newlines, and nothing else. The rest of the test logic—`expect(ascii).not.toMatch(...)`—remains unchanged. Concretely, in `e2e/tools-drawing.spec.ts`, on line 347, replace the old regex with the new, more specific one. No new imports or helpers are needed; this is a pure regex edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
