### PR TITLE
Fix ASCII Art Misalignment in Exported Text

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 rust = { version = "stable", targets = "wasm32-unknown-unknown" }
 node = "22"
-"cargo:wasm-bindgen-cli" = "0.2.114"
+"cargo:wasm-bindgen-cli" = "0.2.117"
 "github:WebAssembly/binaryen" = "latest"

--- a/src/core/ascii_export.rs
+++ b/src/core/ascii_export.rs
@@ -73,10 +73,6 @@ fn export_trimmed(grid: &Grid, options: &ExportOptions) -> String {
             result.push(ch);
         }
 
-        // Trim trailing spaces from this line
-        let trimmed_end = result.trim_end_matches(' ').len();
-        result.truncate(trimmed_end);
-
         if y < max_y {
             result.push('\n');
         }
@@ -140,10 +136,6 @@ pub fn export_region(grid: &Grid, x1: i32, y1: i32, x2: i32, y2: i32) -> String 
             let ch = grid.get(x as i32, y as i32).map(|c| c.ch).unwrap_or(' ');
             result.push(ch);
         }
-        // Trim trailing spaces
-        let trimmed = result.trim_end_matches(' ');
-        result.truncate(trimmed.len());
-
         if y < max_y {
             result.push('\n');
         }
@@ -180,6 +172,37 @@ mod tests {
         let result = export_grid(&grid, &options);
 
         assert_eq!(result, "Hi");
+    }
+
+    #[test]
+    fn test_export_padding_preserves_geometry() {
+        let mut grid = Grid::new(10, 10);
+        // Create a diamond-like shape
+        //   .
+        //  / \
+        //  \ /
+        //   '
+        grid.set_char(5, 2, '.');
+        grid.set_char(4, 3, '/');
+        grid.set_char(6, 3, '\\');
+        grid.set_char(4, 4, '\\');
+        grid.set_char(6, 4, '/');
+        grid.set_char(5, 5, '\'');
+
+        let options = ExportOptions::default();
+        let result = export_grid(&grid, &options);
+
+        let lines: Vec<&str> = result.lines().collect();
+        assert_eq!(lines.len(), 4);
+        // Every line should have the same length (3 characters: index 4 to 6)
+        for line in &lines {
+            assert_eq!(line.len(), 3, "Line '{}' should be padded to length 3", line);
+        }
+
+        assert_eq!(lines[0], " . ");
+        assert_eq!(lines[1], "/ \\");
+        assert_eq!(lines[2], "\\ /");
+        assert_eq!(lines[3], " ' ");
     }
 
     #[test]

--- a/src/core/ascii_export.rs
+++ b/src/core/ascii_export.rs
@@ -197,7 +197,7 @@ mod tests {
         // Every line should have the same length (3 characters: index 4 to 6)
         for line in &lines {
             assert_eq!(
-                line.len(),
+                line.chars().count(),
                 3,
                 "Line '{}' should be padded to length 3",
                 line

--- a/src/core/ascii_export.rs
+++ b/src/core/ascii_export.rs
@@ -196,7 +196,12 @@ mod tests {
         assert_eq!(lines.len(), 4);
         // Every line should have the same length (3 characters: index 4 to 6)
         for line in &lines {
-            assert_eq!(line.len(), 3, "Line '{}' should be padded to length 3", line);
+            assert_eq!(
+                line.len(),
+                3,
+                "Line '{}' should be padded to length 3",
+                line
+            );
         }
 
         assert_eq!(lines[0], " . ");

--- a/web/main.ts
+++ b/web/main.ts
@@ -942,7 +942,7 @@ async function copyAsciiToClipboard(text: string) {
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;');
 
-        const html = `<pre style="font-family:'JetBrains Mono','Cascadia Code','Courier New',monospace;font-size:14px;line-height:1.25;white-space:pre;">${escapedText}</pre>`;
+        const html = `<pre style="font-family:'JetBrains Mono','Cascadia Code','Courier New',monospace;font-size:14px;line-height:1.4;white-space:pre;">${escapedText}</pre>`;
         const rich = new Blob([html], { type: 'text/html' });
 
         await navigator.clipboard.write([

--- a/web/main.ts
+++ b/web/main.ts
@@ -715,11 +715,7 @@ function handleEventResult(result: EventResult) {
     }
 
     if (result.should_copy && result.ascii) {
-        navigator.clipboard.writeText(result.ascii).then(() => {
-            showToast('Copied to clipboard!');
-        }).catch(() => {
-            showToast('Failed to copy', true);
-        });
+        void copyAsciiToClipboard(result.ascii);
     }
 
     updateUI();
@@ -933,17 +929,49 @@ function updateUI() {
 }
 
 /**
+ * Copy ASCII to clipboard with both plain text and HTML formats
+ * to preserve formatting in various editors.
+ */
+async function copyAsciiToClipboard(text: string) {
+    try {
+        const plain = new Blob([text], { type: 'text/plain' });
+
+        // HTML version with specific font stack to preserve monospace layout
+        const escapedText = text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+
+        const html = `<pre style="font-family:'JetBrains Mono','Cascadia Code','Courier New',monospace;font-size:14px;line-height:1.25;white-space:pre;">${escapedText}</pre>`;
+        const rich = new Blob([html], { type: 'text/html' });
+
+        await navigator.clipboard.write([
+            new ClipboardItem({
+                'text/plain': plain,
+                'text/html': rich,
+            }),
+        ]);
+
+        showToast('Copied — paste in a monospace editor');
+    } catch (err) {
+        console.error('Failed to copy:', err);
+        // Fallback to simple text copy if ClipboardItem is not supported
+        try {
+            await navigator.clipboard.writeText(text);
+            showToast('Copied — paste in a monospace editor');
+        } catch {
+            showToast('Failed to copy', true);
+        }
+    }
+}
+
+/**
  * Copy ASCII to clipboard
  */
 async function copyToClipboard() {
     if (!editor) return;
     const ascii = editor.exportAscii();
-    try {
-        await navigator.clipboard.writeText(ascii);
-        showToast('Copied to clipboard!');
-    } catch {
-        showToast('Failed to copy', true);
-    }
+    await copyAsciiToClipboard(ascii);
 }
 
 /**


### PR DESCRIPTION
This PR fixes the issue where exported ASCII art (e.g., diamonds) appears collapsed or scattered when pasted into external editors like Notepad. 

The primary fix is in the Rust core (`src/core/ascii_export.rs`), where line trimming has been replaced with padding. This ensures that every line in the exported bounding box has the same width, anchoring characters in their correct columns even if they are surrounded by spaces.

The secondary fix is in the frontend (`web/main.ts`), where clipboard operations now provide both plain text and HTML payloads. The HTML payload includes a monospace font stack and CSS `white-space: pre`, which allows rich-text-aware editors (like Word, Notion, or OneNote) to preserve the intended layout automatically.

Finally, the UI toast message has been updated to guide users toward using monospace editors for the best results.

---
*PR created automatically by Jules for task [11531018653923609969](https://jules.google.com/task/11531018653923609969) started by @d-o-hub*