### PR TITLE
Fix workflow dry run and enable automated bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
       dry_run:
         description: 'Dry run (no actual release)'
         required: false
-        default: 'false'
-        type: string
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      is_dry_run: ${{ github.inputs.dry_run == 'true' }}
+      is_dry_run: ${{ inputs.dry_run == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,8 +50,8 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          INPUT_VERSION="${{ github.inputs.version }}"
-          IS_DRY_RUN="${{ github.inputs.dry_run }}"
+          INPUT_VERSION="${{ inputs.version }}"
+          IS_DRY_RUN="${{ inputs.dry_run }}"
           
           if [ "$IS_DRY_RUN" == "true" ]; then
             echo "Dry run mode - using 0.0.0-dryrun"
@@ -200,6 +200,63 @@ jobs:
           
           cat release_body.md
 
+      - name: Bump versions and update files
+        id: bump
+        run: |
+          VERSION="${{ needs.guard-rails.outputs.version }}"
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "v0.1.1")
+          PREV_VERSION=${PREV_TAG#v}
+
+          # Setup git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Update Cargo.toml
+          sed -i "s/version = \"$PREV_VERSION\"/version = \"$VERSION\"/" Cargo.toml
+
+          # Update package.json (root)
+          sed -i "s/\"version\": \"$PREV_VERSION\"/\"version\": \"$VERSION\"/" package.json
+
+          # Update web/package.json
+          sed -i "s/\"version\": \"$PREV_VERSION\"/\"version\": \"$VERSION\"/" web/package.json
+
+          # Update package-lock.json files
+          npm --no-git-tag-version version $VERSION || true
+          cd web && npm --no-git-tag-version version $VERSION || true && cd ..
+
+          # Update other md files (e.g. plans/PROJECT_STATUS.md)
+          find . -name "*.md" -not -path "*/node_modules/*" -not -name "CHANGELOG.md" -exec sed -i "s/$PREV_VERSION/$VERSION/g" {} +
+
+          # Prepend to CHANGELOG.md
+          TODAY=$(date +%Y-%m-%d)
+          CHANGES=$(git log --pretty=format:"- %s (%h)" "$PREV_TAG..HEAD" 2>/dev/null | grep -v "^$" || git log --pretty=format:"- %s (%h)" -n 20 | grep -v "^$")
+
+          # Create temporary file with new changelog entry
+          cat > new_changelog_entry.md << TEMP_EOF
+          ## [$VERSION] - $TODAY
+
+          ### Changes
+          $CHANGES
+
+          TEMP_EOF
+
+          # Combine changelog
+          awk -v entry="$(cat new_changelog_entry.md)" \
+              '/^## \[/ { if (!inserted) { print entry; print ""; inserted=1 } } { print }' CHANGELOG.md > CHANGELOG.tmp
+          mv CHANGELOG.tmp CHANGELOG.md
+          rm new_changelog_entry.md
+
+          # Commit and push changes
+          git add Cargo.toml package.json package-lock.json web/package.json web/package-lock.json CHANGELOG.md || true
+          # Add md files
+          git add $(find . -name "*.md" -not -path "*/node_modules/*") || true
+          git diff --quiet && git diff --staged --quiet || git commit -a -m "chore: bump version to $VERSION"
+          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}
+          git push origin HEAD || true
+
+          # Save new tag target to output
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
       - name: Create Release
         id: create_release
         env:
@@ -212,7 +269,7 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --notes-file release_body.md \
-            --target "${{ github.sha }}"
+            --target "${{ steps.bump.outputs.commit_sha || github.sha }}"
 
   publish-wasm:
     name: Publish WASM


### PR DESCRIPTION
- Fixed the dry run configuration in `.github/workflows/release.yml` so that it actually reads `inputs.dry_run` instead of the old unsupported `github.inputs.dry_run`. Changed `type` to `boolean` to leverage a native checkbox.
- Added a `Bump versions and update files` step in the `create-release` job before the final release. It dynamically updates `Cargo.toml`, `package.json`, `CHANGELOG.md` and related md files, matching the generated tag.
- It then commits and pushes these automated bumps back to the repo, enabling automated chore bumping without manual intervention.

---
*PR created automatically by Jules for task [6781657883970141355](https://jules.google.com/task/6781657883970141355) started by @d-o-hub*