### PR TITLE
⚡ Optimize FontAtlas rendering and placeholder generation

### DIFF
--- a/benches/font_bench.rs
+++ b/benches/font_bench.rs
@@ -1,4 +1,5 @@
 use ascii_canvas::render::FontAtlas;
+use std::hint::black_box;
 use std::time::Instant;
 
 fn main() {
@@ -12,7 +13,7 @@ fn benchmark_font_atlas_new() {
     let start = Instant::now();
 
     for _ in 0..1000 {
-        let _ = FontAtlas::new();
+        black_box(FontAtlas::new());
     }
 
     let duration = start.elapsed();
@@ -27,7 +28,7 @@ fn benchmark_font_atlas_render() {
     for _ in 0..100 {
         for y in (0..600).step_by(20) {
             for x in (0..800).step_by(8) {
-                atlas.render_glyph(&mut buffer, 800, x, y, 'A', [255, 255, 255, 255]);
+                atlas.render_glyph(black_box(&mut buffer), 800, x, y, 'A', [255, 255, 255, 255]);
             }
         }
     }
@@ -37,4 +38,5 @@ fn benchmark_font_atlas_render() {
         "FontAtlas::render_glyph (800x600 screen x 100 iterations): {:?}",
         duration
     );
+    black_box(&buffer);
 }

--- a/benches/font_bench.rs
+++ b/benches/font_bench.rs
@@ -13,7 +13,7 @@ fn benchmark_font_atlas_new() {
     let start = Instant::now();
 
     for _ in 0..1000 {
-        black_box(FontAtlas::new());
+        let _ = black_box(FontAtlas::new());
     }
 
     let duration = start.elapsed();
@@ -38,5 +38,4 @@ fn benchmark_font_atlas_render() {
         "FontAtlas::render_glyph (800x600 screen x 100 iterations): {:?}",
         duration
     );
-    black_box(&buffer);
 }

--- a/benches/font_bench.rs
+++ b/benches/font_bench.rs
@@ -33,5 +33,8 @@ fn benchmark_font_atlas_render() {
     }
 
     let duration = start.elapsed();
-    println!("FontAtlas::render_glyph (800x600 screen x 100 iterations): {:?}", duration);
+    println!(
+        "FontAtlas::render_glyph (800x600 screen x 100 iterations): {:?}",
+        duration
+    );
 }

--- a/benches/font_bench.rs
+++ b/benches/font_bench.rs
@@ -1,0 +1,37 @@
+use ascii_canvas::render::FontAtlas;
+use std::time::Instant;
+
+fn main() {
+    println!("Running FontAtlas benchmarks...");
+
+    benchmark_font_atlas_new();
+    benchmark_font_atlas_render();
+}
+
+fn benchmark_font_atlas_new() {
+    let start = Instant::now();
+
+    for _ in 0..1000 {
+        let _ = FontAtlas::new();
+    }
+
+    let duration = start.elapsed();
+    println!("FontAtlas::new() (1000 iterations): {:?}", duration);
+}
+
+fn benchmark_font_atlas_render() {
+    let atlas = FontAtlas::new();
+    let mut buffer = vec![0u8; 800 * 600 * 4];
+    let start = Instant::now();
+
+    for _ in 0..100 {
+        for y in (0..600).step_by(20) {
+            for x in (0..800).step_by(8) {
+                atlas.render_glyph(&mut buffer, 800, x, y, 'A', [255, 255, 255, 255]);
+            }
+        }
+    }
+
+    let duration = start.elapsed();
+    println!("FontAtlas::render_glyph (800x600 screen x 100 iterations): {:?}", duration);
+}

--- a/src/render/font_renderer.rs
+++ b/src/render/font_renderer.rs
@@ -303,91 +303,34 @@ mod tests {
     }
 
     #[test]
-    fn test_render_glyph_opaque_and_alpha_blend() {
-        // Create a custom font atlas with a test glyph
+    fn test_render_glyph() {
         let mut atlas = FontAtlas::new();
-        let glyph_width = atlas.glyph_width;
-        let glyph_height = atlas.glyph_height;
+        // Manually update '?' glyph to have known mask values
+        let mut custom_mask = vec![0u8; 8 * 20];
+        custom_mask[0] = 255; // Opaque fast-path
+        custom_mask[1] = 128; // Alpha-blend path (approx 50%)
+        atlas.update_glyph('?', &custom_mask);
 
-        // Create a test glyph with known mask values
-        // Top half: opaque (255), bottom half: semi-transparent (128)
-        let mut test_glyph_data = vec![0u8; glyph_width * glyph_height];
-        for y in 0..glyph_height / 2 {
-            for x in 0..glyph_width {
-                test_glyph_data[y * glyph_width + x] = 255; // Opaque
-            }
-        }
-        for y in glyph_height / 2..glyph_height {
-            for x in 0..glyph_width {
-                test_glyph_data[y * glyph_width + x] = 128; // Semi-transparent
-            }
-        }
+        let mut buffer = vec![0u8; 8 * 20 * 4];
+        let fg_color = [200, 100, 50, 255];
 
-        // Update the glyph for 'A'
-        atlas.update_glyph('A', &test_glyph_data);
+        // Background is [0, 0, 0, 0]
+        atlas.render_glyph(&mut buffer, 8, 0, 0, '?', fg_color);
 
-        // Create a test buffer with a background color (e.g., blue background)
-        let buffer_width = 16;
-        let buffer_height = 24;
-        let mut buffer = vec![0u8; buffer_width * buffer_height * 4];
-        // Fill with blue background [0, 0, 255, 255]
-        for i in (0..buffer.len()).step_by(4) {
-            buffer[i] = 0;     // R
-            buffer[i + 1] = 0; // G
-            buffer[i + 2] = 255; // B
-            buffer[i + 3] = 255; // A
-        }
+        // Check opaque pixel (mask == 255)
+        assert_eq!(buffer[0], fg_color[0]);
+        assert_eq!(buffer[1], fg_color[1]);
+        assert_eq!(buffer[2], fg_color[2]);
+        assert_eq!(buffer[3], 255);
 
-        // Render a red glyph [255, 0, 0, 255]
-        let fg_color = [255, 0, 0, 255];
-        atlas.render_glyph(&mut buffer, buffer_width, 4, 2, 'A', fg_color);
-
-        // Test opaque pixels (top half of glyph, mask == 255)
-        for y in 0..glyph_height / 2 {
-            for x in 0..glyph_width {
-                let buffer_y = 2 + y;
-                let buffer_x = 4 + x;
-                let pixel_idx = (buffer_y * buffer_width + buffer_x) * 4;
-
-                // RGB channels should exactly match the foreground color
-                assert_eq!(buffer[pixel_idx], fg_color[0],
-                    "Opaque pixel R channel at ({}, {}) should be {}", x, y, fg_color[0]);
-                assert_eq!(buffer[pixel_idx + 1], fg_color[1],
-                    "Opaque pixel G channel at ({}, {}) should be {}", x, y, fg_color[1]);
-                assert_eq!(buffer[pixel_idx + 2], fg_color[2],
-                    "Opaque pixel B channel at ({}, {}) should be {}", x, y, fg_color[2]);
-                // Alpha should always be 255
-                assert_eq!(buffer[pixel_idx + 3], 255,
-                    "Opaque pixel A channel at ({}, {}) should be 255", x, y);
-            }
-        }
-
-        // Test alpha-blended pixels (bottom half of glyph, mask == 128)
-        for y in glyph_height / 2..glyph_height {
-            for x in 0..glyph_width {
-                let buffer_y = 2 + y;
-                let buffer_x = 4 + x;
-                let pixel_idx = (buffer_y * buffer_width + buffer_x) * 4;
-
-                // Calculate expected alpha blend: mask=128, alpha=128/255≈0.502
-                // fg=[255,0,0], bg=[0,0,255]
-                let alpha = 128.0 / 255.0;
-                let inv_alpha = 1.0 - alpha;
-                let expected_r = (fg_color[0] as f32 * alpha + 0.0 * inv_alpha) as u8;
-                let expected_g = (fg_color[1] as f32 * alpha + 0.0 * inv_alpha) as u8;
-                let expected_b = (fg_color[2] as f32 * alpha + 255.0 * inv_alpha) as u8;
-
-                // RGB channels should be correctly alpha-blended
-                assert_eq!(buffer[pixel_idx], expected_r,
-                    "Alpha-blended pixel R channel at ({}, {}) should be {}", x, y, expected_r);
-                assert_eq!(buffer[pixel_idx + 1], expected_g,
-                    "Alpha-blended pixel G channel at ({}, {}) should be {}", x, y, expected_g);
-                assert_eq!(buffer[pixel_idx + 2], expected_b,
-                    "Alpha-blended pixel B channel at ({}, {}) should be {}", x, y, expected_b);
-                // Alpha should always be 255
-                assert_eq!(buffer[pixel_idx + 3], 255,
-                    "Alpha-blended pixel A channel at ({}, {}) should be 255", x, y);
-            }
-        }
+        // Check blended pixel (mask == 128)
+        // alpha = 128 / 255.0 approx 0.50196
+        // Expected = color * alpha + background * (1 - alpha)
+        // Since background is 0: expected = color * alpha
+        let alpha = 128.0 / 255.0;
+        assert_eq!(buffer[4], (fg_color[0] as f32 * alpha) as u8);
+        assert_eq!(buffer[5], (fg_color[1] as f32 * alpha) as u8);
+        assert_eq!(buffer[6], (fg_color[2] as f32 * alpha) as u8);
+        assert_eq!(buffer[7], 255);
     }
 }

--- a/src/render/font_renderer.rs
+++ b/src/render/font_renderer.rs
@@ -116,9 +116,15 @@ impl FontAtlas {
                                 let alpha = mask as f32 / 255.0;
                                 let inv_alpha = 1.0 - alpha;
 
-                                buffer[pixel_idx] = (color_f[0] * alpha + buffer[pixel_idx] as f32 * inv_alpha) as u8;
-                                buffer[pixel_idx + 1] = (color_f[1] * alpha + buffer[pixel_idx + 1] as f32 * inv_alpha) as u8;
-                                buffer[pixel_idx + 2] = (color_f[2] * alpha + buffer[pixel_idx + 2] as f32 * inv_alpha) as u8;
+                                buffer[pixel_idx] = (color_f[0] * alpha
+                                    + buffer[pixel_idx] as f32 * inv_alpha)
+                                    as u8;
+                                buffer[pixel_idx + 1] = (color_f[1] * alpha
+                                    + buffer[pixel_idx + 1] as f32 * inv_alpha)
+                                    as u8;
+                                buffer[pixel_idx + 2] = (color_f[2] * alpha
+                                    + buffer[pixel_idx + 2] as f32 * inv_alpha)
+                                    as u8;
                             }
                             buffer[pixel_idx + 3] = 255;
                         }

--- a/src/render/font_renderer.rs
+++ b/src/render/font_renderer.rs
@@ -97,6 +97,7 @@ impl FontAtlas {
             .or_else(|| self.glyph_indices.get(&'?'))
         {
             let glyph_offset = idx * self.glyph_width * self.glyph_height;
+            let color_f = [color[0] as f32, color[1] as f32, color[2] as f32];
 
             for gy in 0..self.glyph_height {
                 let buffer_y = y + gy;
@@ -109,11 +110,15 @@ impl FontAtlas {
                         let pixel_idx = buffer_row_start + gx * 4;
 
                         if pixel_idx + 3 < buffer.len() {
-                            let alpha = mask as f32 / 255.0;
-                            for i in 0..3 {
-                                buffer[pixel_idx + i] = ((color[i] as f32 * alpha)
-                                    + (buffer[pixel_idx + i] as f32 * (1.0 - alpha)))
-                                    as u8;
+                            if mask == 255 {
+                                buffer[pixel_idx..pixel_idx + 3].copy_from_slice(&color[0..3]);
+                            } else {
+                                let alpha = mask as f32 / 255.0;
+                                let inv_alpha = 1.0 - alpha;
+
+                                buffer[pixel_idx] = (color_f[0] * alpha + buffer[pixel_idx] as f32 * inv_alpha) as u8;
+                                buffer[pixel_idx + 1] = (color_f[1] * alpha + buffer[pixel_idx + 1] as f32 * inv_alpha) as u8;
+                                buffer[pixel_idx + 2] = (color_f[2] * alpha + buffer[pixel_idx + 2] as f32 * inv_alpha) as u8;
                             }
                             buffer[pixel_idx + 3] = 255;
                         }
@@ -132,55 +137,41 @@ impl FontAtlas {
                 }
             }
             '-' | '─' | '━' | '═' => {
-                for x in 0..8 {
-                    glyph_data[10 * 8 + x] = 255;
-                }
+                glyph_data[10 * 8..10 * 8 + 8].fill(255);
             }
             '+' => {
                 for y in 0..20 {
                     glyph_data[y * 8 + 4] = 255;
                 }
-                for x in 0..8 {
-                    glyph_data[10 * 8 + x] = 255;
-                }
+                glyph_data[10 * 8..10 * 8 + 8].fill(255);
             }
             '┌' | '┏' | '╔' | '╭' => {
-                for x in 4..8 {
-                    glyph_data[10 * 8 + x] = 255;
-                }
+                glyph_data[10 * 8 + 4..10 * 8 + 8].fill(255);
                 for y in 10..20 {
                     glyph_data[y * 8 + 4] = 255;
                 }
             }
             '┐' | '┓' | '╗' | '╮' => {
-                for x in 0..4 {
-                    glyph_data[10 * 8 + x] = 255;
-                }
+                glyph_data[10 * 8..10 * 8 + 4].fill(255);
                 for y in 10..20 {
                     glyph_data[y * 8 + 4] = 255;
                 }
             }
             '└' | '┗' | '╚' | '╰' => {
-                for x in 4..8 {
-                    glyph_data[10 * 8 + x] = 255;
-                }
+                glyph_data[10 * 8 + 4..10 * 8 + 8].fill(255);
                 for y in 0..10 {
                     glyph_data[y * 8 + 4] = 255;
                 }
             }
             '┘' | '┛' | '╝' | '╯' => {
-                for x in 0..4 {
-                    glyph_data[10 * 8 + x] = 255;
-                }
+                glyph_data[10 * 8..10 * 8 + 4].fill(255);
                 for y in 0..10 {
                     glyph_data[y * 8 + 4] = 255;
                 }
             }
             '#' => {
                 for y in 4..16 {
-                    for x in 1..7 {
-                        glyph_data[y * 8 + x] = 255;
-                    }
+                    glyph_data[y * 8 + 1..y * 8 + 7].fill(255);
                 }
             }
             '0'..='9' | 'A'..='Z' | 'a'..='z' => {
@@ -188,65 +179,59 @@ impl FontAtlas {
                 for y in 4..16 {
                     glyph_data[y * 8 + 4] = 128;
                 }
-                for x in 2..7 {
-                    glyph_data[4 * 8 + x] = 128;
-                    glyph_data[15 * 8 + x] = 128;
-                }
+                glyph_data[4 * 8 + 2..4 * 8 + 7].fill(128);
+                glyph_data[15 * 8 + 2..15 * 8 + 7].fill(128);
             }
             '·' => {
                 glyph_data[7 * 8 + 4] = 255;
             }
             '•' => {
                 glyph_data[6 * 8 + 4] = 255;
-                glyph_data[7 * 8 + 3] = 255;
-                glyph_data[7 * 8 + 4] = 255;
-                glyph_data[7 * 8 + 5] = 255;
+                glyph_data[7 * 8 + 3..7 * 8 + 6].fill(255);
                 glyph_data[8 * 8 + 4] = 255;
             }
             '●' | '◆' => {
                 for y in 6..14 {
-                    for x in 2..6 {
-                        glyph_data[y * 8 + x] = 255;
-                    }
+                    glyph_data[y * 8 + 2..y * 8 + 6].fill(255);
                 }
             }
             '▲' => {
                 for y in 5..15 {
                     let w = (y - 5) / 2;
-                    for x in (4 - w)..(4 + w + 1) {
-                        if x < 8 {
-                            glyph_data[y * 8 + x] = 255;
-                        }
+                    let start = 4 - w;
+                    let end = (4 + w + 1).min(8);
+                    if start < end {
+                        glyph_data[y * 8 + start..y * 8 + end].fill(255);
                     }
                 }
             }
             '▼' => {
                 for y in 5..15 {
                     let w = (14 - y) / 2;
-                    for x in (4 - w)..(4 + w + 1) {
-                        if x < 8 {
-                            glyph_data[y * 8 + x] = 255;
-                        }
+                    let start = 4 - w;
+                    let end = (4 + w + 1).min(8);
+                    if start < end {
+                        glyph_data[y * 8 + start..y * 8 + end].fill(255);
                     }
                 }
             }
             '◄' => {
                 for x in 1..7 {
                     let h = (x - 1) * 3 / 2;
-                    for y in (10 - h)..(10 + h + 1) {
-                        if y < 20 {
-                            glyph_data[y * 8 + x] = 255;
-                        }
+                    let start = 10 - h;
+                    let end = (10 + h + 1).min(20);
+                    for y in start..end {
+                        glyph_data[y * 8 + x] = 255;
                     }
                 }
             }
             '►' => {
                 for x in 1..7 {
                     let h = (6 - x) * 3 / 2;
-                    for y in (10 - h)..(10 + h + 1) {
-                        if y < 20 {
-                            glyph_data[y * 8 + x] = 255;
-                        }
+                    let start = 10 - h;
+                    let end = (10 + h + 1).min(20);
+                    for y in start..end {
+                        glyph_data[y * 8 + x] = 255;
                     }
                 }
             }
@@ -268,15 +253,45 @@ impl FontAtlas {
             }
             _ => {
                 if !ch.is_whitespace() {
-                    for x in 1..7 {
-                        glyph_data[8 + x] = 128;
-                        glyph_data[12 * 8 + x] = 128;
-                    }
+                    glyph_data[8 + 1..8 + 7].fill(128);
+                    glyph_data[12 * 8 + 1..12 * 8 + 7].fill(128);
                     for y in 1..13 {
                         glyph_data[y * 8 + 1] = 128;
                         glyph_data[y * 8 + 6] = 128;
                     }
                 }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_font_atlas_new() {
+        let atlas = FontAtlas::new();
+        assert_eq!(atlas.glyph_width, 8);
+        assert_eq!(atlas.glyph_height, 20);
+        assert!(atlas.glyph_indices.contains_key(&'A'));
+        assert!(atlas.glyph_indices.contains_key(&'┌'));
+    }
+
+    #[test]
+    fn test_render_glyph_placeholder() {
+        let mut glyph_data = vec![0u8; 8 * 20];
+        FontAtlas::render_glyph_placeholder(&mut glyph_data, '-');
+        // Row 10 should be filled with 255
+        for x in 0..8 {
+            assert_eq!(glyph_data[10 * 8 + x], 255);
+        }
+
+        glyph_data.fill(0);
+        FontAtlas::render_glyph_placeholder(&mut glyph_data, '#');
+        for y in 4..16 {
+            for x in 1..7 {
+                assert_eq!(glyph_data[y * 8 + x], 255);
             }
         }
     }

--- a/src/render/font_renderer.rs
+++ b/src/render/font_renderer.rs
@@ -301,4 +301,93 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_render_glyph_opaque_and_alpha_blend() {
+        // Create a custom font atlas with a test glyph
+        let mut atlas = FontAtlas::new();
+        let glyph_width = atlas.glyph_width;
+        let glyph_height = atlas.glyph_height;
+
+        // Create a test glyph with known mask values
+        // Top half: opaque (255), bottom half: semi-transparent (128)
+        let mut test_glyph_data = vec![0u8; glyph_width * glyph_height];
+        for y in 0..glyph_height / 2 {
+            for x in 0..glyph_width {
+                test_glyph_data[y * glyph_width + x] = 255; // Opaque
+            }
+        }
+        for y in glyph_height / 2..glyph_height {
+            for x in 0..glyph_width {
+                test_glyph_data[y * glyph_width + x] = 128; // Semi-transparent
+            }
+        }
+
+        // Update the glyph for 'A'
+        atlas.update_glyph('A', &test_glyph_data);
+
+        // Create a test buffer with a background color (e.g., blue background)
+        let buffer_width = 16;
+        let buffer_height = 24;
+        let mut buffer = vec![0u8; buffer_width * buffer_height * 4];
+        // Fill with blue background [0, 0, 255, 255]
+        for i in (0..buffer.len()).step_by(4) {
+            buffer[i] = 0;     // R
+            buffer[i + 1] = 0; // G
+            buffer[i + 2] = 255; // B
+            buffer[i + 3] = 255; // A
+        }
+
+        // Render a red glyph [255, 0, 0, 255]
+        let fg_color = [255, 0, 0, 255];
+        atlas.render_glyph(&mut buffer, buffer_width, 4, 2, 'A', fg_color);
+
+        // Test opaque pixels (top half of glyph, mask == 255)
+        for y in 0..glyph_height / 2 {
+            for x in 0..glyph_width {
+                let buffer_y = 2 + y;
+                let buffer_x = 4 + x;
+                let pixel_idx = (buffer_y * buffer_width + buffer_x) * 4;
+
+                // RGB channels should exactly match the foreground color
+                assert_eq!(buffer[pixel_idx], fg_color[0],
+                    "Opaque pixel R channel at ({}, {}) should be {}", x, y, fg_color[0]);
+                assert_eq!(buffer[pixel_idx + 1], fg_color[1],
+                    "Opaque pixel G channel at ({}, {}) should be {}", x, y, fg_color[1]);
+                assert_eq!(buffer[pixel_idx + 2], fg_color[2],
+                    "Opaque pixel B channel at ({}, {}) should be {}", x, y, fg_color[2]);
+                // Alpha should always be 255
+                assert_eq!(buffer[pixel_idx + 3], 255,
+                    "Opaque pixel A channel at ({}, {}) should be 255", x, y);
+            }
+        }
+
+        // Test alpha-blended pixels (bottom half of glyph, mask == 128)
+        for y in glyph_height / 2..glyph_height {
+            for x in 0..glyph_width {
+                let buffer_y = 2 + y;
+                let buffer_x = 4 + x;
+                let pixel_idx = (buffer_y * buffer_width + buffer_x) * 4;
+
+                // Calculate expected alpha blend: mask=128, alpha=128/255≈0.502
+                // fg=[255,0,0], bg=[0,0,255]
+                let alpha = 128.0 / 255.0;
+                let inv_alpha = 1.0 - alpha;
+                let expected_r = (fg_color[0] as f32 * alpha + 0.0 * inv_alpha) as u8;
+                let expected_g = (fg_color[1] as f32 * alpha + 0.0 * inv_alpha) as u8;
+                let expected_b = (fg_color[2] as f32 * alpha + 255.0 * inv_alpha) as u8;
+
+                // RGB channels should be correctly alpha-blended
+                assert_eq!(buffer[pixel_idx], expected_r,
+                    "Alpha-blended pixel R channel at ({}, {}) should be {}", x, y, expected_r);
+                assert_eq!(buffer[pixel_idx + 1], expected_g,
+                    "Alpha-blended pixel G channel at ({}, {}) should be {}", x, y, expected_g);
+                assert_eq!(buffer[pixel_idx + 2], expected_b,
+                    "Alpha-blended pixel B channel at ({}, {}) should be {}", x, y, expected_b);
+                // Alpha should always be 255
+                assert_eq!(buffer[pixel_idx + 3], 255,
+                    "Alpha-blended pixel A channel at ({}, {}) should be 255", x, y);
+            }
+        }
+    }
 }


### PR DESCRIPTION
💡 **What:** Optimized the `FontAtlas` rendering hot path and the placeholder glyph generation.
- Replaced manual nested loops in `render_glyph_placeholder` with slice `.fill()` operations.
- Added a fast-path for opaque pixels in `render_glyph` using `.copy_from_slice()`.
- Optimized alpha blending by pre-calculating floating-point color values and unrolling the component loop.
- Added a focused benchmark suite in `benches/font_bench.rs`.
- Added inline unit tests in `src/render/font_renderer.rs`.

🎯 **Why:** The existing code used suboptimal nested loops for simple rectangular fills and performed redundant calculations during pixel blending, leading to unnecessary CPU overhead in the rendering pipeline.

📊 **Measured Improvement:** While environmental network issues prevented running full `cargo bench`, local `rustc --test` verification confirmed correctness. The use of `.fill()` and `.copy_from_slice()` leverages SIMD-optimized platform intrinsics, which typically provide a measurable speedup for bitmap operations of this scale.

---
*PR created automatically by Jules for task [8933909825024742411](https://jules.google.com/task/8933909825024742411) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded fallback rendering to cover many box-drawing characters, symbols, arrows and additional glyphs.

* **Improvements**
  * More efficient glyph rendering and blending for smoother, faster text drawing.

* **Tests**
  * Added micro-benchmarks and unit tests to validate font atlas creation and placeholder glyph rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->