### PR TITLE
🧪 [test] add bounds check tests for grid indexing

### DIFF
--- a/src/core/grid.rs
+++ b/src/core/grid.rs
@@ -297,4 +297,27 @@ mod tests {
         assert!(grid.get(1, 2).unwrap().is_empty());
         assert!(grid.get(6, 2).unwrap().is_empty());
     }
+
+    #[test]
+    fn test_grid_indexing_out_of_bounds() {
+        let grid = Grid::new(10, 10);
+
+        // index_of with out-of-bounds coordinates
+        // The function does not check bounds, it just performs the math.
+        assert_eq!(grid.index_of(10, 10), 110);
+        assert_eq!(grid.index_of(0, 10), 100);
+        assert_eq!(grid.index_of(10, 0), 10);
+
+        // coords_of with out-of-bounds index
+        // Again, just math without bounds check.
+        assert_eq!(grid.coords_of(100), (0, 10));
+        assert_eq!(grid.coords_of(105), (5, 10));
+        assert_eq!(grid.coords_of(110), (0, 11));
+
+        // Very large index
+        let large_index = usize::MAX;
+        let (x, y) = grid.coords_of(large_index);
+        assert_eq!(x, large_index % 10);
+        assert_eq!(y, large_index / 10);
+    }
 }

--- a/tests/core/grid.rs
+++ b/tests/core/grid.rs
@@ -83,3 +83,27 @@ fn test_grid_indexing() {
     let idx = grid.index_of(5, 3);
     assert_eq!(grid[idx].ch, 'A');
 }
+
+#[test]
+fn test_grid_indexing_behavior() {
+    let grid = Grid::new(10, 10);
+
+    // Test coords_of/index_of symmetry
+    for y in 0..10 {
+        for x in 0..10 {
+            let idx = grid.index_of(x, y);
+            assert_eq!(grid.coords_of(idx), (x, y));
+        }
+    }
+
+    // Test out-of-bounds behavior (should be consistent math)
+    assert_eq!(grid.index_of(10, 10), 110);
+    assert_eq!(grid.coords_of(110), (0, 11));
+
+    // High index test
+    let max_idx = 1000;
+    let (x, y) = grid.coords_of(max_idx);
+    assert_eq!(x, 0);
+    assert_eq!(y, 100);
+    assert_eq!(grid.index_of(x, y), max_idx);
+}


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap for `Grid::index_of` and `Grid::coords_of` by implementing tests for out-of-bounds scenarios.
📊 **Coverage:**
- `index_of` with coordinates beyond width/height.
- `coords_of` with indices exceeding total grid size.
- Round-trip symmetry between coordinates and indices.
- Edge case with `usize::MAX`.
✨ **Result:** Increased test reliability and verified the mathematical consistency of the grid coordinate system.

---
*PR created automatically by Jules for task [12296870926234226401](https://jules.google.com/task/12296870926234226401) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for grid indexing calculations with out-of-bounds scenarios and high-index values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->