### PR TITLE
build(deps): update wasm-bindgen requirement from =0.2.118 to =0.2.121

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/anomalyco/ascii-canvas"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.118"
+wasm-bindgen = "=0.2.121"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 rust = { version = "stable", targets = "wasm32-unknown-unknown" }
 node = "22"
-"cargo:wasm-bindgen-cli" = "0.2.118"
+"cargo:wasm-bindgen-cli" = "0.2.121"
 "github:WebAssembly/binaryen" = "latest"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:wasm": "cargo build --target wasm32-unknown-unknown --release && wasm-bindgen target/wasm32-unknown-unknown/release/ascii_canvas.wasm --out-dir web/pkg --target web && wasm-opt --enable-simd --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -O3 web/pkg/ascii_canvas_bg.wasm -o web/pkg/ascii_canvas_bg.wasm",
     "build:web": "cd web && npm run build",
     "build": "npm run build:wasm && npm run build:web",
-    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.118 && npm i -g wasm-opt && npm ci && cd web && npm ci && cd .. && npm run build && npm run check-size",
+    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.121 && npm i -g wasm-opt && npm ci && cd web && npm ci && cd .. && npm run build && npm run check-size",
     "dev": "cd web && npm run dev",
     "test": "cargo test && npx playwright test --project=chromium",
     "test:unit": "cargo test",


### PR DESCRIPTION
Updates the `wasm-bindgen` dependency from version `0.2.118` to `0.2.121`.
This includes updates to:
- `Cargo.toml` (`wasm-bindgen = "=0.2.121"`)
- `mise.toml` (`"cargo:wasm-bindgen-cli" = "0.2.121"`)
- `package.json` (`netlify:build` script to use `wasm-bindgen-cli --version 0.2.121`)

Pre-commit steps run:
- successfully executed native unit tests with `cargo test`
- successfully executed WASM tests via `WASM_BINDGEN_TEST_ONLY_NODE=1 cargo test --all --target wasm32-unknown-unknown`
- successfully ran `cargo clippy --all-targets --all-features -- -D warnings`
- successfully built frontend logic and assets (`npm run build`)
- successfully completed size check (`npm run check-size`)

---
*PR created automatically by Jules for task [5448245858190115597](https://jules.google.com/task/5448245858190115597) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated wasm-bindgen dependencies to version 0.2.121 across build configuration files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/rust-ascii-canvas/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->