### PR TITLE
🎨 Palette: UX Polish and Accessibility Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-04-24 - [Contextual Cursors and Tool Instructions]
 **Learning:** Providing immediate visual (cursor) and textual (status bar instructions) feedback when switching tools significantly reduces the cognitive load for new users. Monospace diagrams can be complex to edit; simple "how-to" snippets in the status bar provide just-in-time guidance.
 **Action:** Implement tool-specific cursors and status bar hints to guide user interactions without cluttering the main UI.
+
+## 2026-05-28 - [Contextual Feedback and Navigation]
+**Learning:** Contextual visual feedback for specialized tools (like Eraser or Selection) reduces user error and increases confidence. Providing a dedicated "Reset Zoom" shortcut (and documenting it) improves navigation in large diagrams.
+**Action:** Always consider tool-specific cursor indicators and "escape hatches" like zoom reset for canvas-based interfaces.

--- a/web/index.html
+++ b/web/index.html
@@ -75,7 +75,7 @@
 
                 <!-- Border Style -->
                 <div class="tool-group" role="group" aria-label="Border Style">
-                    <select id="border-style" class="select-input" title="Border Style (B)">
+                    <select id="border-style" class="select-input" title="Border Style (B)" aria-label="Border style">
                         <option value="single">Single (─)</option>
                         <option value="double">Double (═)</option>
                         <option value="heavy">Heavy (━)</option>
@@ -248,6 +248,7 @@
                         <div class="shortcut-row"><kbd>Ctrl+C</kbd> <span>Copy ASCII</span></div>
                         <div class="shortcut-row"><kbd>Space+Drag</kbd> <span>Pan Canvas</span></div>
                         <div class="shortcut-row"><kbd>Scroll</kbd> <span>Zoom In/Out</span></div>
+                        <div class="shortcut-row"><kbd>0</kbd> <span>Reset Zoom</span></div>
                         <div class="shortcut-row"><kbd>Escape</kbd> <span>Cancel/Deselect</span></div>
                     </div>
                 </div>

--- a/web/main.ts
+++ b/web/main.ts
@@ -726,9 +726,7 @@ function handleKeyDown(e: KeyboardEvent) {
     // Handle 0 key - reset zoom
     if (key === '0' && !ctrl && !shift) {
         setZoom(1.0);
-        if (editor) {
-            editor.setPan(0, 0);
-        }
+        editor.setPan(0, 0);
         showToast('Zoom reset to 100%');
     }
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -723,6 +723,15 @@ function handleKeyDown(e: KeyboardEvent) {
         cycleBorderStyle();
     }
 
+    // Handle 0 key - reset zoom
+    if (key === '0' && !ctrl && !shift) {
+        setZoom(1.0);
+        if (editor) {
+            editor.setPan(0, 0);
+        }
+        showToast('Zoom reset to 100%');
+    }
+
     // Handle ? key - show keyboard shortcuts modal
     if (key === '?' || (key === '/' && shift)) {
         showShortcutsModal();
@@ -990,11 +999,15 @@ function updateToolButtons(activeTool: string) {
     // Update cursor
     if (canvasContainer && info) {
         // Clear previous tool classes
-        canvasContainer.classList.remove('tool-text', 'tool-select', 'tool-crosshair');
+        canvasContainer.classList.remove('tool-text', 'tool-select', 'tool-crosshair', 'tool-eraser');
         if (info.cursor === 'text') {
             canvasContainer.classList.add('tool-text');
         } else if (info.cursor === 'crosshair') {
-            canvasContainer.classList.add('tool-crosshair');
+            if (normalizedTool === 'eraser') {
+                canvasContainer.classList.add('tool-eraser');
+            } else {
+                canvasContainer.classList.add('tool-crosshair');
+            }
         } else if (normalizedTool === 'select') {
             canvasContainer.classList.add('tool-select');
         }

--- a/web/style.css
+++ b/web/style.css
@@ -363,6 +363,15 @@ body {
     opacity: 0;
 }
 
+.canvas-container.tool-select .cursor-indicator {
+    border-style: dashed;
+}
+
+.canvas-container.tool-eraser .cursor-indicator {
+    border-color: var(--error);
+    background-color: rgba(242, 72, 34, 0.2);
+}
+
 /* Side Panel */
 .side-panel {
     width: 220px;

--- a/web/ux.test.ts
+++ b/web/ux.test.ts
@@ -11,6 +11,7 @@ describe('UX Improvements', () => {
             <button class="tool-btn" data-tool="rectangle"></button>
             <button class="tool-btn" data-tool="text"></button>
             <button class="tool-btn" data-tool="select"></button>
+            <button class="tool-btn" data-tool="eraser"></button>
         `;
     });
 
@@ -34,6 +35,10 @@ describe('UX Improvements', () => {
 
         updateToolButtons('select');
         expect(container?.classList.contains('tool-select')).toBe(true);
+        expect(container?.classList.contains('tool-crosshair')).toBe(false);
+
+        updateToolButtons('eraser');
+        expect(container?.classList.contains('tool-eraser')).toBe(true);
         expect(container?.classList.contains('tool-crosshair')).toBe(false);
     });
 


### PR DESCRIPTION
💡 What: This PR adds a few micro-UX improvements to the ASCII Canvas Editor.
- A new keyboard shortcut '0' resets the zoom to 100% and resets the pan offset.
- The Selection tool now shows a dashed cursor indicator.
- The Eraser tool now shows a red cursor indicator with a light red background to warn of its destructive nature.
- Added `aria-label="Border style"` to the border style dropdown for better accessibility.
- Updated the Keyboard Shortcuts modal to include the new '0' shortcut.

🎯 Why: These changes make the editor more intuitive by providing better visual feedback about the active tool and improving navigation. The accessibility addition ensures better support for screen reader users.

♿ Accessibility: Added ARIA label to the border style selection element.

---
*PR created automatically by Jules for task [3325629757542759301](https://jules.google.com/task/3325629757542759301) started by @d-o-hub*