### PR TITLE
🎨 Palette: Improve shortcut accessibility and discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-05-28 - [Contextual Feedback and Navigation]
 **Learning:** Contextual visual feedback for specialized tools (like Eraser or Selection) reduces user error and increases confidence. Providing a dedicated "Reset Zoom" shortcut (and documenting it) improves navigation in large diagrams.
 **Action:** Always consider tool-specific cursor indicators and "escape hatches" like zoom reset for canvas-based interfaces.
+
+## 2026-05-29 - [Shortcut Discoverability and ARIA metadata]
+**Learning:** Essential productivity shortcuts (like "Select All" or "Reset Zoom") should be mirrored in the primary side-panel reference, not just hidden in help modals. Additionally, using `aria-keyshortcuts` on toolbar buttons provides a standard way for assistive technologies to communicate keyboard triggers that are otherwise only visible in tooltips.
+**Action:** Always verify that the quick-reference shortcut list covers all high-frequency actions and ensure toolbar buttons have explicit ARIA shortcut metadata.

--- a/web/index.html
+++ b/web/index.html
@@ -24,15 +24,15 @@
             <div class="toolbar-center">
                 <!-- Tools -->
                 <div class="tool-group" role="group" aria-label="Drawing Tools">
-                    <button class="tool-btn" data-tool="select" title="Select (V)" aria-label="Select tool">
+                    <button class="tool-btn" data-tool="select" title="Select (V)" aria-label="Select tool" aria-keyshortcuts="V">
                         <span class="tool-icon">⬚</span>
                         <span class="tool-label">Select</span>
                     </button>
-                    <button class="tool-btn" data-tool="rectangle" title="Rectangle (R)" aria-label="Rectangle tool">
+                    <button class="tool-btn" data-tool="rectangle" title="Rectangle (R)" aria-label="Rectangle tool" aria-keyshortcuts="R">
                         <span class="tool-icon">▢</span>
                         <span class="tool-label">Rect</span>
                     </button>
-                    <button class="tool-btn" data-tool="line" title="Line (L)" aria-label="Line tool">
+                    <button class="tool-btn" data-tool="line" title="Line (L)" aria-label="Line tool" aria-keyshortcuts="L">
                         <span class="tool-icon">╱</span>
                         <span class="tool-label">Line</span>
                     </button>
@@ -48,24 +48,24 @@
                             <span class="tool-icon">│</span>
                         </button>
                     </div>
-                    <button class="tool-btn" data-tool="arrow" title="Arrow (A)" aria-label="Arrow tool">
+                    <button class="tool-btn" data-tool="arrow" title="Arrow (A)" aria-label="Arrow tool" aria-keyshortcuts="A">
                         <span class="tool-icon">→</span>
                         <span class="tool-label">Arrow</span>
                     </button>
-                    <button class="tool-btn" data-tool="diamond" title="Diamond (D)" aria-label="Diamond tool">
+                    <button class="tool-btn" data-tool="diamond" title="Diamond (D)" aria-label="Diamond tool" aria-keyshortcuts="D">
                         <span class="tool-icon">◇</span>
                         <span class="tool-label">Diamond</span>
                     </button>
                     <div class="tool-separator"></div>
-                    <button class="tool-btn" data-tool="text" title="Text (T)" aria-label="Text tool">
+                    <button class="tool-btn" data-tool="text" title="Text (T)" aria-label="Text tool" aria-keyshortcuts="T">
                         <span class="tool-icon">T</span>
                         <span class="tool-label">Text</span>
                     </button>
-                    <button class="tool-btn" data-tool="freehand" title="Freehand (F)" aria-label="Freehand tool">
+                    <button class="tool-btn" data-tool="freehand" title="Freehand (F)" aria-label="Freehand tool" aria-keyshortcuts="F">
                         <span class="tool-icon">✎</span>
                         <span class="tool-label">Free</span>
                     </button>
-                    <button class="tool-btn" data-tool="eraser" title="Eraser (E)" aria-label="Eraser tool">
+                    <button class="tool-btn" data-tool="eraser" title="Eraser (E)" aria-label="Eraser tool" aria-keyshortcuts="E">
                         <span class="tool-icon">⌫</span>
                         <span class="tool-label">Erase</span>
                     </button>
@@ -184,10 +184,16 @@
                             <kbd>E</kbd> <span>Eraser</span>
                         </div>
                         <div class="shortcut-item">
+                            <kbd>B</kbd> <span>Border</span>
+                        </div>
+                        <div class="shortcut-item">
                             <kbd>Ctrl+Z</kbd> <span>Undo</span>
                         </div>
                         <div class="shortcut-item">
                             <kbd>Ctrl+Shift+Z</kbd> <span>Redo</span>
+                        </div>
+                        <div class="shortcut-item">
+                            <kbd>Ctrl+A</kbd> <span>Select All</span>
                         </div>
                         <div class="shortcut-item">
                             <kbd>Ctrl+C</kbd> <span>Copy</span>
@@ -197,6 +203,15 @@
                         </div>
                         <div class="shortcut-item">
                             <kbd>Scroll</kbd> <span>Zoom</span>
+                        </div>
+                        <div class="shortcut-item">
+                            <kbd>0</kbd> <span>Reset Zoom</span>
+                        </div>
+                        <div class="shortcut-item">
+                            <kbd>Esc</kbd> <span>Deselect</span>
+                        </div>
+                        <div class="shortcut-item">
+                            <kbd>?</kbd> <span>Help</span>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
💡 What:
- Added `aria-keyshortcuts` to all primary drawing tool buttons in the toolbar (Select, Rectangle, Line, Arrow, Diamond, Text, Freehand, Eraser).
- Expanded the side panel "Shortcuts" list to include high-frequency actions previously hidden in the help modal: Border (B), Reset Zoom (0), Select All (Ctrl+A), Deselect (Esc), and Help (?).

🎯 Why:
- Improves accessibility for screen reader users by explicitly communicating keyboard triggers.
- Enhances discoverability for new users by providing a more comprehensive quick-reference guide in the persistent side panel.

♿ Accessibility:
- Implemented `aria-keyshortcuts` on 8 toolbar buttons.
- Ensured consistency between visual tooltips and ARIA metadata.

---
*PR created automatically by Jules for task [5478424078013678652](https://jules.google.com/task/5478424078013678652) started by @d-o-hub*