### PR TITLE
🎨 Palette: Improve zoom centering and shortcut discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-05-29 - [Shortcut Discoverability and ARIA metadata]
 **Learning:** Essential productivity shortcuts (like "Select All" or "Reset Zoom") should be mirrored in the primary side-panel reference, not just hidden in help modals. Additionally, using `aria-keyshortcuts` on toolbar buttons provides a standard way for assistive technologies to communicate keyboard triggers that are otherwise only visible in tooltips.
 **Action:** Always verify that the quick-reference shortcut list covers all high-frequency actions and ensure toolbar buttons have explicit ARIA shortcut metadata.
+
+## 2026-07-10 - [Centering Logic and Robust Shortcuts]
+**Learning:** Centering the grid content in the viewport after zoom or fit-to-view actions significantly improves the professional feel and interaction quality of the editor. Furthermore, providing character-based fallbacks for shortcuts (e.g., handling ')' for Shift+0) ensures that keyboard interactions remain accessible across different international keyboard layouts.
+**Action:** Always calculate centering pan offsets when modifying canvas scale and implement character-level checks for shortcuts that involve Shift or Alt modifiers.

--- a/web/index.html
+++ b/web/index.html
@@ -148,8 +148,8 @@
                         </div>
                     </div>
                     <div class="zoom-controls">
-                        <button class="zoom-btn" id="zoom-fit" title="Fit to View" aria-label="Fit to view">Fit</button>
-                        <button class="zoom-btn" id="zoom-reset" title="Reset Zoom (100%)" aria-label="Reset zoom to 100%">1:1</button>
+                        <button class="zoom-btn" id="zoom-fit" title="Fit to View (Shift+0)" aria-label="Fit to view" aria-keyshortcuts="Shift+0 )">Fit</button>
+                        <button class="zoom-btn" id="zoom-reset" title="Reset Zoom (0)" aria-label="Reset zoom to 100%" aria-keyshortcuts="0">1:1</button>
                         <button class="zoom-btn" id="zoom-out" title="Zoom Out (-)" aria-label="Zoom out" aria-keyshortcuts="-">-</button>
                         <button class="zoom-btn" id="zoom-in" title="Zoom In (+)" aria-label="Zoom in" aria-keyshortcuts="+">+</button>
                     </div>
@@ -208,6 +208,9 @@
                             <kbd>0</kbd> <span>Reset Zoom</span>
                         </div>
                         <div class="shortcut-item">
+                            <kbd>Shift+0</kbd> <span>Fit to View</span>
+                        </div>
+                        <div class="shortcut-item">
                             <kbd>Esc</kbd> <span>Deselect</span>
                         </div>
                         <div class="shortcut-item">
@@ -264,6 +267,7 @@
                         <div class="shortcut-row"><kbd>Space+Drag</kbd> <span>Pan Canvas</span></div>
                         <div class="shortcut-row"><kbd>Scroll</kbd> <span>Zoom In/Out</span></div>
                         <div class="shortcut-row"><kbd>0</kbd> <span>Reset Zoom</span></div>
+                        <div class="shortcut-row"><kbd>Shift+0</kbd> <span>Fit to View</span></div>
                         <div class="shortcut-row"><kbd>Escape</kbd> <span>Cancel/Deselect</span></div>
                     </div>
                 </div>

--- a/web/main.ts
+++ b/web/main.ts
@@ -502,7 +502,7 @@ function setupEventListeners() {
     zoomResetBtn.addEventListener('mousedown', (e) => e.preventDefault());
     zoomResetBtn.addEventListener('click', () => {
         if (!editor) return;
-        setZoom(1.0);
+        resetZoom();
         if (canvas) canvas.focus();
     });
 
@@ -741,11 +741,13 @@ function handleKeyDown(e: KeyboardEvent) {
             cycleBorderStyle();
         }
 
-        // Handle 0 key - reset zoom
-        if (key === '0' && !ctrl && !shift) {
-            setZoom(1.0);
-            editor.setPan(0, 0);
-            showToast('Zoom reset to 100%');
+        // Handle 0 key - reset zoom or fit to view
+        if ((key === '0' || key === ')') && !ctrl) {
+            if (shift || key === ')') {
+                fitZoom();
+            } else {
+                resetZoom();
+            }
         }
 
         // Handle ? key - show keyboard shortcuts modal
@@ -1120,23 +1122,47 @@ function setZoom(zoom: number) {
 }
 
 /**
+ * Reset zoom level to 100% and center the grid
+ */
+function resetZoom() {
+    if (!editor || !canvasContainer) return;
+
+    const containerRect = canvasContainer.getBoundingClientRect();
+    const gridWidth = editor.width * charWidth;
+    const gridHeight = editor.height * lineHeight;
+
+    const panX = (containerRect.width - gridWidth) / 2;
+    const panY = (containerRect.height - gridHeight) / 2;
+
+    setZoom(1.0);
+    editor.setPan(panX, panY);
+    editor.requestRedraw();
+    requestRender();
+    showToast('Zoom reset to 100%');
+}
+
+/**
  * Fit zoom to show entire canvas
  */
 function fitZoom() {
     if (!editor || !canvasContainer) return;
-    
+
     const containerRect = canvasContainer.getBoundingClientRect();
     const gridWidth = editor.width * charWidth;
     const gridHeight = editor.height * lineHeight;
-    
+
     const zoomX = containerRect.width / (gridWidth + 40);
     const zoomY = containerRect.height / (gridHeight + 40);
-    const fitZoom = Math.min(zoomX, zoomY, 1.0);
-    
-    setZoom(fitZoom);
-    editor.setPan(0, 0);
+    const fitZoomLevel = Math.min(zoomX, zoomY, 1.0);
+
+    const panX = (containerRect.width - gridWidth * fitZoomLevel) / 2;
+    const panY = (containerRect.height - gridHeight * fitZoomLevel) / 2;
+
+    setZoom(fitZoomLevel);
+    editor.setPan(panX, panY);
     editor.requestRedraw();
     requestRender();
+    showToast('Zoom fitted to view');
 }
 
 /**


### PR DESCRIPTION
This micro-UX improvement enhances the canvas navigation experience by ensuring the grid is always centered when resetting zoom or fitting to view. 

Key changes:
- Added `resetZoom()` and updated `fitZoom()` in `web/main.ts` with centering logic.
- Implemented `Shift+0` and `)` as shortcuts for 'Fit to View'.
- Improved accessibility by adding `aria-keyshortcuts` to zoom buttons in `web/index.html`.
- Updated shortcut documentation in the side panel and help modal for better discoverability.
- Added visual feedback via status toasts when zoom actions are triggered.

---
*PR created automatically by Jules for task [4860752338358324259](https://jules.google.com/task/4860752338358324259) started by @d-o-hub*