### PR TITLE
feat(harness): harness engineering for agents, CI, and quality gates

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: code-review
+description: >
+  Inferential code review sensor for this repo. Use before asking a human to review,
+  after verify gates are green, or when asked to "review", "review changes", or
+  "pre-review". Checks harness compliance, architecture layers, test adequacy, and
+  agent failure modes — not a substitute for cargo/clippy/CI.
+---
+
+# Code Review (Inferential Feedback)
+
+Semantic review **after** computational sensors (`verify` skill / `npm run gate:*`) are green. Complements CI; does not replace it.
+
+## When to Use
+
+- Before opening a PR or requesting human review
+- After a large agent-authored diff
+- User asks for review / pre-review / sanity check of changes
+
+## Don't Invoke When
+
+- Gates are still red — run `verify` first
+- You need automated rustc/clippy (use computational sensors)
+
+## Prerequisites
+
+```bash
+npm run gate:fast   # minimum
+# Prefer gate:full if product behaviour changed
+```
+
+## Review checklist
+
+### 1. Intent and scope
+
+- [ ] Diff matches the requested goal (no drive-by features)
+- [ ] No over-engineering or speculative abstractions
+- [ ] Spec / issue / ADR referenced when behaviour changes
+
+### 2. Architecture fitness
+
+- [ ] `core` stays pure (no wasm/web-sys)
+- [ ] Logic not dumped into `wasm/helpers.rs` or `web/main.ts` when it belongs in core/modules
+- [ ] No new file >500 LOC; allowlisted files not grown without extraction plan
+- [ ] Public WASM / document format changes are intentional and tested
+
+### 3. Maintainability
+
+- [ ] Names and module split match existing patterns
+- [ ] Error paths handled; no silent `unwrap` on fallible user paths without justification
+- [ ] Comments explain **why**, not narrate **what**
+- [ ] No secrets, personal emails, or debug leftovers
+
+### 4. Behaviour / tests
+
+- [ ] Tests fail for the bug they claim to catch (not only happy path)
+- [ ] Tool/UI changes covered by unit, Vitest, or E2E as appropriate
+- [ ] Clipboard, persistence, layers: fidelity edge cases considered
+- [ ] No flaky `waitForTimeout` introduced in E2E
+
+### 5. Harness coherence
+
+- [ ] If a recurring agent mistake was fixed, a guide or sensor was updated
+- [ ] CI/scripts/docs still agree (`AGENTS.md` tiers vs `quality-gates.sh`)
+- [ ] PR description will mention harness changes if any
+
+## Known agent failure modes (watch for)
+
+| Mode | What to look for |
+|------|------------------|
+| Misdiagnosis | Fix unrelated to root cause; tests green but bug remains |
+| Brute-force | Huge unrelated rewrites; `#[allow]` spam; deleted tests |
+| Over-engineering | Extra traits/layers for a local fix |
+| Incomplete verification | Only ran one unit test; skipped web/architecture |
+| Layer bleed | Browser types in `core`; business rules only in TS |
+
+## Output format
+
+```markdown
+## Review summary
+**Verdict:** Approve | Approve with nits | Request changes
+**Gates:** fast/full assumed green? yes/no
+
+## Findings
+### Blocking
+- ...
+
+### Nits
+- ...
+
+## Harness follow-ups
+- (sensors/guides to add, or none)
+```
+
+## Integration
+
+- **After** `verify`
+- **Before** human PR / `create-github-pull-request-from-specification`
+- **Escalation:** architecture disputes → ADR via `goap-adr-planner`

--- a/.agents/skills/tool-validation/SKILL.md
+++ b/.agents/skills/tool-validation/SKILL.md
@@ -1,6 +1,13 @@
+---
+name: tool-validation
+description: >
+  Behaviour harness for the 8 ASCII Canvas drawing tools. Use when changing tools,
+  canvas interaction, border styles, or when AGENTS.md tool checklist applies.
+---
+
 # Tool Validation Skill
 
-This skill provides a standardized methodology for validating the 8 drawing tools in the ASCII Canvas editor.
+Behaviour-harness methodology for the 8 drawing tools. Complements computational sensors (`verify` / E2E). See [agents-docs/harness.md](../../../agents-docs/harness.md).
 
 ## Verification Checklist
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -51,22 +51,35 @@ Part of the project **harness** ([agents-docs/harness.md](../../../agents-docs/h
 - rustfmt, clippy `-D warnings`, build, `cargo test`
 - architecture layer rules
 - LOC (non-allowlisted)
+- **ensures `web/pkg` exists** (builds WASM if missing — pkg is gitignored)
 - web ESLint, `tsc --noEmit`, Vitest
 - privacy / secret scan
 
 ## What full adds
 
 - cargo audit / deny (if installed)
-- `pnpm run build:wasm` + `check-size` (≤ 1.5MB)
+- `pnpm run build:wasm` + `check-size` (≤ 1.5MB) if not already built
 - Playwright Chromium E2E
+
+## CI parity checks (do not skip)
+
+| CI job | Local equivalent | Gotcha |
+|--------|------------------|--------|
+| Web tsc | `cd web && pnpm exec tsc --noEmit` | Needs `web/pkg` (gitignored). Clean tree: `npm run build:wasm` first. See harness **L-001**. |
+| Architecture | `./scripts/check-architecture.sh` | Needs `rg` |
+| WASM size | `npm run check-size` | After `build:wasm` |
+| E2E | `npx playwright test --project=chromium` | Needs pkg + dev server |
+
+If CI fails but local gates passed, treat it as a **harness bug**: update sensors so local fails the same way (append to `agents-docs/harness.md` Learned failure modes).
 
 ## Steering loop
 
 If you hit the **same** failure class twice in a session (or it recurred from a past PR):
 
-1. Fix product code.
-2. Strengthen harness: new test, clearer `AGENTS.md` rule, or sensor message.
-3. Note in `plans/TECHNICAL_ANALYSIS.md` when non-obvious.
+1. Fix product / CI code.
+2. Strengthen harness: new test, clearer `AGENTS.md` rule, sensor message, or CI job dependency.
+3. Append a short entry under **Learned failure modes** in `agents-docs/harness.md`.
+4. Note in `plans/TECHNICAL_ANALYSIS.md` when non-obvious.
 
 ## Integration
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: verify
+description: >
+  Run tiered computational quality sensors and self-correct. Use after code changes,
+  before commits/PRs, when asked to "verify", "run gates", "quality check", or when
+  AGENTS.md requires verification. Prefer gate:fast during iteration and gate:full
+  before handoff.
+---
+
+# Verify (Computational Feedback)
+
+Part of the project **harness** ([agents-docs/harness.md](../../../agents-docs/harness.md)). Runs deterministic sensors and drives the agent self-correction loop.
+
+## When to Use
+
+- After implementing or refactoring product code
+- Before opening a PR or asking for human review
+- When CI failed and you need the local equivalent
+- User says verify / gate / quality check / pre-commit
+
+## Don't Invoke When
+
+- Pure documentation-only edits with no scripts/CI change (optional smoke only)
+- You only need a single focused unit test mid-TDD (run that test first, then verify)
+
+## Tiers (keep quality left)
+
+| Tier | Command | Use |
+|------|---------|-----|
+| **fast** | `npm run gate:fast` | Default after edits |
+| **full** | `npm run gate:full` | Before PR |
+| **architecture only** | `./scripts/check-architecture.sh` | Layer/import changes |
+| **focused** | `cargo test …` / `cd web && pnpm test` / one Playwright file | Tight loop |
+
+## Procedure
+
+1. **Choose tier** — fast unless shipping or touching WASM/E2E behaviour → full.
+2. **Run sensor**:
+   ```bash
+   npm run gate:fast
+   # or
+   npm run gate:full
+   ```
+3. **On failure** — read `[FAIL]` and `FIX:` lines. Fix root cause. Re-run the same tier.
+4. **Do not** disable sensors, add blanket `#[allow]`, skip tests, or expand `.loc-allowlist` without an ADR.
+5. **Behaviour changes** to tools — also run `tool-validation` skill / relevant E2E.
+6. **Before human review** — run `code-review` skill after full gates are green.
+
+## What fast covers
+
+- rustfmt, clippy `-D warnings`, build, `cargo test`
+- architecture layer rules
+- LOC (non-allowlisted)
+- web ESLint, `tsc --noEmit`, Vitest
+- privacy / secret scan
+
+## What full adds
+
+- cargo audit / deny (if installed)
+- `pnpm run build:wasm` + `check-size` (≤ 1.5MB)
+- Playwright Chromium E2E
+
+## Steering loop
+
+If you hit the **same** failure class twice in a session (or it recurred from a past PR):
+
+1. Fix product code.
+2. Strengthen harness: new test, clearer `AGENTS.md` rule, or sensor message.
+3. Note in `plans/TECHNICAL_ANALYSIS.md` when non-obvious.
+
+## Integration
+
+- **Handoff from** `rust-engineer` / `typescript-expert` → verify
+- **Handoff to** `code-review` → human PR
+- **Related** `tool-validation`, `dogfood`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,28 +2,28 @@
 
 <!-- Briefly describe your changes -->
 
-## Changes Made
+## Changes made
 
-<!-- What changes were made? -->
+<!-- What changed and why -->
 
-## Testing
+## Testing (harness)
 
-- [ ] Tests pass (`cargo test`)
-- [ ] Clippy passes (`cargo clippy`)
-- [ ] Formatting is correct (`cargo fmt`)
-- [ ] E2E tests pass (`npx playwright test --project=chromium`)
+- [ ] Fast gates: `npm run gate:fast` (fmt, clippy, tests, architecture, web lint/tsc/vitest)
+- [ ] Full gates (if product behaviour): `npm run gate:full` (WASM, size, E2E)
+- [ ] Or equivalent CI jobs green
 
 ## Checklist
 
-- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
-- [ ] My code follows the project's coding conventions
-- [ ] I have updated documentation where applicable
-- [ ] I have added tests that prove my fix is effective or my feature works
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
+- [ ] Architecture layers respected (`core` pure; see `agents-docs/architecture.md`)
+- [ ] Documentation / ADR updated if decision or harness changed
+- [ ] Tests prove the fix or feature (no weakened assertions)
+- [ ] If a recurring agent/CI failure was fixed: guide or sensor improved
 
 ## Screenshots
 
-<!-- If applicable, add screenshots -->
+<!-- If applicable -->
 
-## Related Issues
+## Related issues
 
-<!-- Link to related issues (e.g., "Closes #123") -->
+<!-- e.g. Closes #123 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,50 +208,14 @@ jobs:
       - uses: actions/checkout@v7
       - uses: EmbarkStudios/cargo-deny-action@v2
 
-  web:
-    name: Web (Lint + Types + Unit)
-    needs: [changes]
-    if: >
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.web == 'true' ||
-      needs.changes.outputs.harness == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10
-
-      - name: Install web dependencies
-        working-directory: web
-        run: pnpm install --frozen-lockfile
-
-      - name: ESLint
-        working-directory: web
-        run: pnpm run lint
-
-      - name: TypeScript (strict)
-        working-directory: web
-        run: pnpm exec tsc --noEmit
-
-      - name: Vitest
-        working-directory: web
-        run: pnpm test
-
+  # WASM first: web/pkg is gitignored; tsc and e2e both need generated bindings.
   wasm:
     name: WASM Build
     needs: [changes]
     if: >
       github.event_name != 'pull_request' ||
       needs.changes.outputs.product == 'true' ||
+      needs.changes.outputs.web == 'true' ||
       needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -289,6 +253,53 @@ jobs:
           name: wasm-pkg
           path: web/pkg
 
+  web:
+    name: Web (Lint + Types + Unit)
+    needs: [changes, wasm]
+    # web/pkg is gitignored — TypeScript imports ./pkg/ascii_canvas.js and needs the WASM artifact.
+    if: >
+      always() &&
+      (github.event_name != 'pull_request' ||
+       needs.changes.outputs.web == 'true' ||
+       needs.changes.outputs.harness == 'true') &&
+      needs.wasm.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Install web dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: Download WASM pkg (required for tsc)
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-pkg
+          path: web/pkg
+
+      - name: ESLint
+        working-directory: web
+        run: pnpm run lint
+
+      - name: TypeScript (strict)
+        working-directory: web
+        run: pnpm exec tsc --noEmit
+
+      - name: Vitest
+        working-directory: web
+        run: pnpm test
+
   e2e:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest
@@ -297,6 +308,7 @@ jobs:
       always() &&
       (github.event_name != 'pull_request' ||
        needs.changes.outputs.product == 'true' ||
+       needs.changes.outputs.web == 'true' ||
        needs.changes.outputs.harness == 'true') &&
       needs.wasm.result == 'success'
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,31 +20,69 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Path filters keep quality left: only run expensive jobs for relevant changes.
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      rust: ${{ steps.filter.outputs.rust }}
+      web: ${{ steps.filter.outputs.web }}
+      product: ${{ steps.filter.outputs.product }}
+      harness: ${{ steps.filter.outputs.harness }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
-            code:
+            rust:
               - 'src/**'
               - 'tests/**'
               - 'benches/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - 'clippy.toml'
+              - 'rustfmt.toml'
+              - 'deny.toml'
+            web:
+              - 'web/**'
+              - 'e2e/**'
+              - 'playwright.config.ts'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+            harness:
+              - 'scripts/**'
+              - 'AGENTS.md'
+              - 'agents-docs/**'
+              - '.agents/**'
+              - '.loc-allowlist'
+              - '.github/workflows/**'
+            product:
+              - 'src/**'
+              - 'tests/**'
+              - 'benches/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'clippy.toml'
+              - 'rustfmt.toml'
+              - 'deny.toml'
+              - 'web/**'
+              - 'e2e/**'
+              - 'playwright.config.ts'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'scripts/**'
+              - 'mise.toml'
 
   fmt:
     name: Format
     needs: [changes]
     if: >
       github.event_name != 'pull_request' ||
-      needs.changes.outputs.code == 'true'
+      needs.changes.outputs.rust == 'true' ||
+      needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -59,7 +97,8 @@ jobs:
     needs: [changes]
     if: >
       github.event_name != 'pull_request' ||
-      needs.changes.outputs.code == 'true'
+      needs.changes.outputs.rust == 'true' ||
+      needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -70,12 +109,45 @@ jobs:
       - name: Clippy (all targets, all features)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  architecture:
+    name: Architecture Fitness
+    needs: [changes]
+    if: >
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.rust == 'true' ||
+      needs.changes.outputs.harness == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Layer import rules + LOC
+        run: |
+          bash scripts/check-architecture.sh
+          # LOC: fail only on non-allowlisted oversized files
+          max=500
+          failed=0
+          while IFS= read -r file; do
+            lines=$(wc -l < "$file" | tr -d ' ')
+            rel="${file#./}"
+            if [ "$lines" -gt "$max" ]; then
+              if grep -qxF "$rel" .loc-allowlist 2>/dev/null; then
+                echo "WARN: $rel has $lines lines (allowlisted)"
+              else
+                echo "FAIL: $rel has $lines lines (max $max)"
+                failed=1
+              fi
+            fi
+          done < <(find ./src -name '*.rs' -type f | sort)
+          exit $failed
+
   rust:
     name: Rust (Build + Tests)
     needs: [changes]
     if: >
       github.event_name != 'pull_request' ||
-      needs.changes.outputs.code == 'true'
+      needs.changes.outputs.rust == 'true' ||
+      needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -110,7 +182,7 @@ jobs:
     needs: [changes]
     if: >
       github.event_name != 'pull_request' ||
-      needs.changes.outputs.code == 'true'
+      needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -130,18 +202,57 @@ jobs:
     needs: [changes]
     if: >
       github.event_name != 'pull_request' ||
-      needs.changes.outputs.code == 'true'
+      needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: EmbarkStudios/cargo-deny-action@v2
+
+  web:
+    name: Web (Lint + Types + Unit)
+    needs: [changes]
+    if: >
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.web == 'true' ||
+      needs.changes.outputs.harness == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Install web dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: ESLint
+        working-directory: web
+        run: pnpm run lint
+
+      - name: TypeScript (strict)
+        working-directory: web
+        run: pnpm exec tsc --noEmit
+
+      - name: Vitest
+        working-directory: web
+        run: pnpm test
 
   wasm:
     name: WASM Build
     needs: [changes]
     if: >
       github.event_name != 'pull_request' ||
-      needs.changes.outputs.code == 'true'
+      needs.changes.outputs.product == 'true' ||
+      needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -169,6 +280,9 @@ jobs:
           npm install -g wasm-opt
           pnpm run build:wasm
 
+      - name: WASM size budget
+        run: pnpm run check-size
+
       - name: Upload WASM
         uses: actions/upload-artifact@v7
         with:
@@ -178,7 +292,13 @@ jobs:
   e2e:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest
-    needs: [rust, wasm]
+    needs: [changes, wasm]
+    if: >
+      always() &&
+      (github.event_name != 'pull_request' ||
+       needs.changes.outputs.product == 'true' ||
+       needs.changes.outputs.harness == 'true') &&
+      needs.wasm.result == 'success'
     timeout-minutes: 20
 
     steps:
@@ -209,7 +329,7 @@ jobs:
           cd web && pnpm install --frozen-lockfile
 
       - name: Install Playwright
-        run: npx playwright install chromium
+        run: npx playwright install chromium --with-deps
 
       - name: Download WASM
         uses: actions/download-artifact@v8
@@ -236,7 +356,7 @@ jobs:
 
   ci-success:
     name: CI Success
-    needs: [fmt, clippy, rust, security, deny, wasm, e2e]
+    needs: [fmt, clippy, architecture, rust, security, deny, web, wasm, e2e]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -245,9 +365,11 @@ jobs:
           results=(
             "${{ needs.fmt.result }}"
             "${{ needs.clippy.result }}"
+            "${{ needs.architecture.result }}"
             "${{ needs.rust.result }}"
             "${{ needs.security.result }}"
             "${{ needs.deny.result }}"
+            "${{ needs.web.result }}"
             "${{ needs.wasm.result }}"
             "${{ needs.e2e.result }}"
           )

--- a/.loc-allowlist
+++ b/.loc-allowlist
@@ -1,0 +1,4 @@
+# Files allowed to exceed the 500-line limit (known debt).
+# One repo-relative path per line. Do not grow these files — extract modules instead.
+# See agents-docs/architecture.md and ADR-037.
+src/wasm/helpers.rs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,13 @@ Do **not** run the full E2E suite after every one-line fix. Use tiers:
 - `cargo test` (native)
 - Architecture layer check
 - LOC limit (see `.loc-allowlist`)
+- **WASM pkg for typecheck**: `web/pkg` is gitignored; gate builds it if missing (CI downloads the wasm artifact before `tsc`)
 - Web: `pnpm lint`, `tsc --noEmit`, `pnpm test` (when `web/` present)
 - Privacy / secret scan
+
+### CI vs local (learned)
+
+If CI is red and local is green, **do not** only re-run CI. Diff assumptions (artifacts, path filters, env). Fix the **sensor** so local fails the same way next time — see [harness learned failures](agents-docs/harness.md#learned-failure-modes-steering-log) (e.g. L-001 `web/pkg`).
 
 ### What full adds
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,107 @@
-# Agent Best Practices - ASCII Canvas Project
+# Agent Best Practices — ASCII Canvas
 
-This document outlines the core principles and workflows for agents working on this project. Detailed technical references and historical learnings are maintained in the `agents-docs/` directory.
+Outer harness for coding agents. Full map: [agents-docs/harness.md](agents-docs/harness.md). Architecture constraints: [agents-docs/architecture.md](agents-docs/architecture.md).
 
-## Core Directives
+## Core directives
 
-1. **Analyze** - Understand requirements before acting.
-2. **Plan** - Create steps in `plans/` using GOAP and ADR before execution.
-3. **Execute** - Run commands and tests autonomously.
-4. **Document** - Update `plans/` with findings and results.
-5. **Always Verify** - Every change must be followed by a verification tool call.
+1. **Analyze** — understand requirements and which layers you will touch.
+2. **Plan** — multi-step or architectural work → `plans/` + ADR via `goap-adr-planner`.
+3. **Execute** — implement; keep business logic in `src/core/`.
+4. **Verify** — run **fast** sensors after changes; **full** before PR. Use the `verify` skill.
+5. **Document** — update `plans/` / ADRs when decisions or learnings change.
+6. **Steer the harness** — if the same failure happens twice, improve a guide or sensor, not only product code.
 
-## Standard Workflow Checklist
+## Keep quality left (mandatory tiers)
 
-- [ ] Run `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] Run `cargo test` (unit + integration + doc tests)
-- [ ] Build WASM with `npm run build:wasm`
-- [ ] Run ESLint check: `cd web && npm run lint`
-- [ ] Run E2E tests: `npm run test:e2e`
-- [ ] Validate all 8 tools using the **Tool Verification Checklist** below.
-- [ ] Update ADRs for any new architectural decisions in `plans/ADRs/`
-- [ ] Document technical findings in `plans/TECHNICAL_ANALYSIS.md`
-- [ ] Call `pre_commit_instructions` before submitting.
+Do **not** run the full E2E suite after every one-line fix. Use tiers:
 
-## Reference Documentation
+| Tier | When | Command |
+|------|------|---------|
+| **fast** | After every meaningful edit | `npm run gate:fast` |
+| **full** | Before commit/PR that touches product code | `npm run gate:full` |
+| **focused** | While iterating on one area | relevant `cargo test …` / `cd web && pnpm test` / single Playwright file |
 
-- [Core Best Practices](agents-docs/best-practices.md)
-- [Production Readiness Learnings](agents-docs/learnings-archive.md)
-- [Phase 1 Learnings](agents-docs/learnings-archive-phase1.md)
-- [Responsive Grid Guide](agents-docs/responsive-grid.md)
+### What fast includes
 
-## Proactive Testing
+- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test` (native)
+- Architecture layer check
+- LOC limit (see `.loc-allowlist`)
+- Web: `pnpm lint`, `tsc --noEmit`, `pnpm test` (when `web/` present)
+- Privacy / secret scan
 
-### Rust Testing Guidelines
+### What full adds
 
-1. **Unit Tests**: Place in the same file as the source code, at the bottom, within a `#[cfg(test)] mod tests { ... }` block. This is standard Rust idiomatic practice and allows testing private implementation details.
-2. **Integration Tests**: Place in the `tests/` directory to test the crate's public API from the outside.
+- WASM build (`npm run build:wasm`) + size budget
+- E2E Chromium (`npm run test:e2e` / Playwright)
+- `cargo audit` when available
 
-For any code change, attempt to find and run relevant tests. Practice test-driven development when practical. If you encounter failures, diagnose the root cause before attempting environment changes.
+Self-correct on red sensors before asking a human to review. Sensor output includes fix hints — follow them.
 
-## Tool Verification Checklist
+## Architecture constraints (non-negotiable)
 
-| Tool | Core Requirement |
+```
+core (pure) ← render, ui ← wasm ← web/
+```
+
+- `src/core/**` must **not** import `wasm`, `render`, or `ui`.
+- Prefer extracting modules over growing files past **500 LOC**.
+- Details and allowed edges: [agents-docs/architecture.md](agents-docs/architecture.md).
+- Computational check: `./scripts/check-architecture.sh`.
+
+## Rust testing
+
+1. **Unit tests**: same file, `#[cfg(test)] mod tests { … }` (can touch private items).
+2. **Integration tests**: `tests/` for public API only.
+3. On failure: fix root cause; do not weaken assertions or skip CI to “make it green”.
+
+## Web / WASM
+
+- Build WASM: `npm run build:wasm` (wasm-bindgen **0.2.121**, see `mise.toml`).
+- Web lint/test: `cd web && pnpm lint && pnpm exec tsc --noEmit && pnpm test`.
+- E2E: Playwright from repo root; prefer `--project=chromium` locally.
+
+## Tool behaviour checklist (behaviour harness)
+
+When changing drawing tools or canvas interaction, validate:
+
+| Tool | Core requirement |
 |------|------------------|
-| **Select** | Visible blue highlight; move & delete work. |
-| **Rect** | Correct border style corners/lines. |
-| **Line** | Continuous lines in all directions. |
-| **Arrow** | Visible arrowhead (▲▼◄►) at end. |
-| **Diamond** | Uses diagonal characters (╱╲). |
-| **Text** | Supports Enter/Backspace/Delete keys. |
-| **Free** | Character syncs with Border Style. |
-| **Erase** | Radius-based clearing; no out-of-bounds. |
+| **Select** | Visible blue highlight; move & delete work |
+| **Rect** | Correct border style corners/lines |
+| **Line** | Continuous lines in all directions |
+| **Arrow** | Visible arrowhead (▲▼◄►) at end |
+| **Diamond** | Diagonal characters (╱╲) |
+| **Text** | Enter / Backspace / Delete |
+| **Free** | Character syncs with Border Style |
+| **Erase** | Radius-based clear; no OOB |
+
+Use the `tool-validation` skill for the full procedure.
+
+## Skills (by harness role)
+
+| Need | Skill |
+|------|--------|
+| Plan / ADR | `goap-adr-planner` |
+| Run sensors / self-correct | `verify` |
+| Pre-human review | `code-review` |
+| Rust implementation | `rust-engineer`, `rust-best-practices`, `rust-wasm` |
+| TypeScript / Vite | `typescript-expert`, `vite` |
+| Tool QA | `tool-validation` |
+| Exploratory UX | `dogfood` |
+| Maintain this doc | `agents-md` |
+
+## Reference docs
+
+- [Harness map](agents-docs/harness.md)
+- [Architecture](agents-docs/architecture.md)
+- [Best practices](agents-docs/best-practices.md)
+- [Production learnings](agents-docs/learnings-archive.md)
+- [Responsive grid](agents-docs/responsive-grid.md)
+- ADRs: `plans/ADRs/` (see **037-harness-engineering**)
+
+## PR / handoff
+
+- Fast gates green on every push-worthy change; full gates green before review.
+- PR template checkboxes must reflect reality.
+- Call out harness changes (new sensors, allowlist, CI) explicitly in the PR body.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,63 +2,90 @@
 
 Thank you for your interest in contributing!
 
-## Development Setup
+## Development setup
 
 ### Prerequisites
 
-- Rust (latest stable)
-- Node.js 18+
-- wasm-pack (`cargo install wasm-pack`)
+- Rust (stable) with target `wasm32-unknown-unknown`
+- Node.js 22+ and pnpm 10
+- [mise](https://mise.jdx.dev/) recommended (`mise.toml` pins wasm-bindgen-cli **0.2.121** and binaryen)
 
-### Quick Start
+### Quick start
 
 ```bash
-# Clone the repository
-git clone https://github.com/anomalyco/ascii-canvas.git
-cd ascii-canvas
+git clone https://github.com/d-o-hub/rust-ascii-canvas.git
+cd rust-ascii-canvas
 
-# Install Node dependencies
-npm install
+# Toolchain (if using mise)
+mise install
 
-# Build WASM
-wasm-pack build --release --target web --out-dir web/pkg
+# JS deps (root + web)
+pnpm install
+cd web && pnpm install && cd ..
 
-# Start development server
-cd web && npm run dev
+# Build WASM into web/pkg
+pnpm run build:wasm
+
+# Dev server
+pnpm run dev
 ```
 
-## Code Style
+## Quality harness (keep quality left)
 
-- Run `cargo fmt` before committing
-- Run `cargo clippy` to catch common mistakes
-- Keep lines under 100 characters when possible
+This repo uses a **coding-agent harness**: guides + sensors. See `AGENTS.md` and `agents-docs/harness.md`.
 
-## Testing
+| Tier | Command | When |
+|------|---------|------|
+| **fast** | `npm run gate:fast` | Every meaningful change / pre-commit |
+| **full** | `npm run gate:full` | Before opening a PR |
+| Architecture only | `npm run check:architecture` | Layer / import changes |
+
+Optional git hook:
 
 ```bash
-# Run Rust unit tests
-cargo test
+ln -sf ../../scripts/pre-commit-fast.sh .git/hooks/pre-commit
+```
 
-# Run E2E tests (requires dev server)
+### Manual checks
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+cd web && pnpm lint && pnpm exec tsc --noEmit && pnpm test
+pnpm run build:wasm && pnpm run check-size
 npx playwright test --project=chromium
 ```
 
-## Pull Request Process
+## Architecture
 
-1. Create a feature branch from `main`
-2. Make your changes
-3. Ensure all tests pass
-4. Update documentation if needed
-5. Submit a pull request
+- `src/core/` — pure Rust (no WASM/browser APIs)
+- `src/render/`, `src/ui/` — may use core; not wasm
+- `src/wasm/` — JS bindings only
+- `web/` — Vite/TypeScript UI
 
-## Areas to Contribute
+Details: `agents-docs/architecture.md`. File size target: ≤500 lines (known debt in `.loc-allowlist`).
 
-- Drawing tools (select, rectangle, line, arrow, diamond, text, freehand, eraser)
-- Border styles
-- UI/UX improvements
-- Performance optimizations
-- Documentation
+## Code style
 
-## Code of Conduct
+- `cargo fmt` before commit
+- Clippy clean with `-D warnings`
+- Prefer tests next to Rust code (`#[cfg(test)]`) for units; `tests/` for public API
+
+## Pull request process
+
+1. Branch from `main`
+2. Keep `gate:fast` green while iterating; `gate:full` before review
+3. Fill `.github/PULL_REQUEST_TEMPLATE.md` honestly
+4. Link issues (`Closes #…`)
+5. Call out harness/CI/doc changes in the PR body
+
+## Areas to contribute
+
+- Drawing tools, border styles, UI/UX
+- Layers, export, clipboard fidelity
+- Performance, docs, tests, harness sensors
+
+## Code of conduct
 
 Be respectful and constructive. Follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ npm run dev &
 
 The editor will be available at `http://localhost:3003`.
 
+### Quality gates (agent + human)
+
+```shell
+npm run gate:fast   # fmt, clippy, tests, architecture, web lint/tsc/vitest
+npm run gate:full   # + WASM build, size budget, E2E
+```
+
+Coding-agent harness: [`AGENTS.md`](AGENTS.md), [`agents-docs/harness.md`](agents-docs/harness.md). Architecture layers: [`agents-docs/architecture.md`](agents-docs/architecture.md).
+
 ## Project Structure
 
 ```

--- a/agents-docs/AGENTS.md
+++ b/agents-docs/AGENTS.md
@@ -1,8 +1,30 @@
 # Agent Skills - Reference Documentation
 
-This folder contains reference documentation for all agent skills available in the project.
+Reference docs for agent skills. Operational harness: [harness.md](harness.md), [architecture.md](architecture.md). Root directives: [`../AGENTS.md`](../AGENTS.md).
 
-## Available Skills
+## Harness-critical skills
+
+### verify
+- **Location**: `.agents/skills/verify/SKILL.md`
+- **Role**: Computational feedback — run `gate:fast` / `gate:full`, self-correct
+- **Use when**: After code changes, before PR, CI failures
+
+### code-review
+- **Location**: `.agents/skills/code-review/SKILL.md`
+- **Role**: Inferential feedback — architecture, failure modes, harness coherence
+- **Use when**: Gates green; before human review
+
+### tool-validation
+- **Location**: `.agents/skills/tool-validation/SKILL.md`
+- **Role**: Behaviour harness for the 8 drawing tools
+- **Use when**: Tool or canvas interaction changes
+
+### goap-adr-planner
+- **Location**: `.agents/skills/goap-adr-planner/SKILL.md`
+- **Role**: Feedforward planning / ADRs
+- **Use when**: Multi-step work, architecture decisions
+
+## Available skills
 
 ### rust-engineer
 - **Location**: `.agents/skills/rust-engineer/SKILL.md`

--- a/agents-docs/architecture.md
+++ b/agents-docs/architecture.md
@@ -1,0 +1,63 @@
+# Architecture Guide (Feedforward)
+
+Agents **must** read this before changing module boundaries, adding dependencies, or growing large files.
+
+## Layered design
+
+```
+┌─────────────────────────────────────────┐
+│  web/          TypeScript Vite app      │  UI events, DOM, persistence, export
+├─────────────────────────────────────────┤
+│  src/wasm/     wasm-bindgen bindings    │  JS interop only
+├─────────────────────────────────────────┤
+│  src/ui/       shortcuts, theme, toolbar│  Editor chrome (Rust-side config)
+│  src/render/   canvas, dirty rect, font │  May use core; not wasm
+├─────────────────────────────────────────┤
+│  src/core/     grid, tools, commands    │  Pure Rust — no wasm/web-sys
+│  src/utils/    shared math/helpers      │  No layer above
+└─────────────────────────────────────────┘
+```
+
+## Hard rules (enforced by `scripts/check-architecture.sh`)
+
+| From | Must not import |
+|------|-----------------|
+| `src/core/**` | `crate::wasm`, `crate::render`, `crate::ui` |
+| `src/utils/**` | `crate::wasm`, `crate::render`, `crate::ui`, `crate::core` (keep utils leaf-level; prefer no core) |
+| `src/render/**` | `crate::wasm`, `crate::ui` |
+| `src/ui/**` | `crate::wasm`, `crate::render` |
+
+**Allowed:** `wasm` → `core`, `render`, `ui` as needed. `render`/`ui` → `core`. `web/` only talks to WASM public API (`AsciiEditor`), not Rust internals.
+
+## File size
+
+- Soft/hard limit: **500 lines** per source file (`.rs`, and prefer for `.ts` too).
+- Known debt is listed in `.loc-allowlist` (one path per line). **Do not grow allowlisted files**; prefer extracting modules.
+- New files over 500 lines fail the quality gate.
+
+## WASM / web boundary
+
+- Business logic and drawing algorithms live in **core**, not in `web/` or `wasm/helpers.rs`.
+- `web/` modules stay focused: `clipboard.ts`, `persistence.ts`, `exportPng.ts`, `main.ts` orchestration.
+- Public WASM surface should stay stable; prefer additive APIs.
+
+## Testing map
+
+| Layer | Prefer |
+|-------|--------|
+| `core` tools/commands/grid | Unit tests in same file + `tests/core/` |
+| Export / clipboard fidelity | Unit tests + focused E2E |
+| DOM / UX wiring | Vitest where pure; Playwright for integration |
+| All 8 tools | E2E + tool-validation skill |
+
+## Performance / size fitness
+
+- Release WASM size budget: **≤ 1.5MB** (`npm run check-size`).
+- Prefer dirty-rect and sparse structures already in render/core; do not introduce full-grid O(n) work on every mouse move without measuring.
+
+## When you must write an ADR
+
+- New cross-layer dependency or splitting a crate
+- Changing document format (`.asc`), clipboard semantics, or history model
+- New CI quality gate or relaxing an existing one
+- See `plans/ADRs/` and skill `goap-adr-planner`

--- a/agents-docs/best-practices.md
+++ b/agents-docs/best-practices.md
@@ -1,67 +1,56 @@
 # Agent Best Practices - ASCII Canvas Project
 
-## Agent System Overview
+## Agent system overview
 
-This project uses specialized agents with skills for different tasks. All agents should document their work in the `plans/` folder.
+Specialized skills + an explicit **outer harness** (guides + sensors). Start at root [`AGENTS.md`](../AGENTS.md) and [harness.md](harness.md). Document lasting work in `plans/`.
 
-## Best Practices
+## Best practices
 
-### Task Execution
-1. **Analyze** - Understand requirements before acting
-2. **Plan** - Create steps in `plans/` with GOAP with ADR before execution
-3. **Execute** - Run commands and tests
-4. **Document** - Update `plans/` with results
+### Task execution
+1. **Analyze** — requirements and layers touched ([architecture.md](architecture.md))
+2. **Plan** — multi-step work → `plans/` + ADR (`goap-adr-planner`)
+3. **Execute** — implement; keep business logic in `src/core/`
+4. **Verify** — `npm run gate:fast` (iterate) / `gate:full` (handoff); skill `verify`
+5. **Document** — update `plans/` / ADRs; improve harness when failures recur
 
-### Documentation Standards
-- All architectural decisions → `plans/` folder
-- Use ADR format: title, status, date, context, decision, consequences
-- Update `PROJECT_STATUS.md` with test results
-- Add technical findings to `TECHNICAL_ANALYSIS.md`
-- **Always document learnings** - Any new tool, workflow, fix, or best practice discovered during development must be added to `plans/` (e.g., `TECHNICAL_ANALYSIS.md` for technical findings, new ADRs for decisions)
+### Documentation standards
+- Architectural decisions → `plans/ADRs/`
+- Status → `plans/PROJECT_STATUS.md`
+- Technical findings → `plans/TECHNICAL_ANALYSIS.md`
+- Harness inventory → `agents-docs/harness.md`
 
-### Testing Workflow
-1. Build dependencies (WASM, npm packages)
-2. Run tests: `cargo test`, `npx playwright test`
-3. Document results in `plans/`
-4. Update ADRs with learnings
+### Testing workflow (tiered)
+1. Focused tests while TDD’ing
+2. `npm run gate:fast` after meaningful edits
+3. `npm run gate:full` before PR (WASM, size, E2E)
+4. Tool/UI: `tool-validation` + relevant Playwright
 
-### File Organization
+### File organization
 ```
-plans/
-├── PROJECT_STATUS.md      # Current project state
-├── TECHNICAL_ANALYSIS.md  # Technical findings
-└── ADRs/                 # Architectural decisions
-    └── *.md
-
-.agents/skills/
+plans/           # status, ADRs, analysis
+agents-docs/     # harness, architecture, learnings
+.agents/skills/  # verify, code-review, rust-*, etc.
+scripts/         # quality-gates, check-architecture
 ```
 
-### Code Quality
-- Keep files under 500 LOC
-- Use consistent naming conventions
-- Add documentation comments for public APIs
-- Run tests before marking tasks complete
+### Code quality
+- ≤500 LOC per file (exceptions only in `.loc-allowlist`)
+- Computational sensors must stay green; do not skip or weaken
+- Public APIs documented; naming consistent with neighbours
 
 ### Communication
-- Provide structured output with summaries
-- Include specific issues and recommendations
-- Verify ADRs match implementation
+- Structured summaries; explicit harness changes in PRs
+- Prefer FIX hints from quality-gates when self-correcting
 
-### CI/CD Best Practices (2026-03-19)
+### CI/CD (updated 2026-07-16)
 
-1. **Release workflow**: Use `gh release create --target ${{ github.sha }}` to create both tag and release in one step. No manual `git tag` needed.
-2. **GH_TOKEN**: Always set `env: GH_TOKEN: ${{ github.token }}` on steps using `gh` CLI.
-3. **binaryen/wasm-opt**: Download from GitHub releases, not `apt-get`. Ubuntu packages are too old for latest Rust WASM output.
-4. **wasm-opt flags**: Use `--enable-sign-ext` (not `--enable-sign-extension`), `--enable-nontrapping-float-to-int`, `--enable-simd`, `--enable-bulk-memory`.
-5. **Always test CI fixes** — push, trigger, monitor. Fix iteratively until green.
+1. Path filters: **rust**, **web**, **product**, **harness** — web-only PRs still run web + WASM/E2E as needed
+2. Jobs: fmt, clippy, architecture, rust, security, deny, **web** (eslint/tsc/vitest), wasm+size, e2e
+3. Release: `gh release create --target ${{ github.sha }}`; `GH_TOKEN: ${{ github.token }}`
+4. wasm-opt: install recent binaryen; flags `--enable-sign-ext`, `--enable-nontrapping-float-to-int`, `--enable-simd`, `--enable-bulk-memory`
+5. Local mirror of CI left side: `npm run gate:fast`
 
-## Rust Testing Architecture
+## Rust testing architecture
 
-1. **Unit Tests (`src/`)**:
-   - Unit tests **must** live in the same file as the source code they test.
-   - Place them at the bottom of the file within a `#[cfg(test)] mod tests { ... }` block.
-   - This follows standard Rust idiomatic practice, allowing tests to access private functions and variables.
-
-2. **Integration Tests (`tests/`)**:
-   - Only place tests here if they are testing the crate's public API from the outside.
-   - The `tests/` directory is exclusively for integration-level validation.
+1. **Unit tests (`src/`)**: same file, `#[cfg(test)] mod tests`
+2. **Integration tests (`tests/`)**: public API only

--- a/agents-docs/best-practices.md
+++ b/agents-docs/best-practices.md
@@ -45,10 +45,12 @@ scripts/         # quality-gates, check-architecture
 ### CI/CD (updated 2026-07-16)
 
 1. Path filters: **rust**, **web**, **product**, **harness** — web-only PRs still run web + WASM/E2E as needed
-2. Jobs: fmt, clippy, architecture, rust, security, deny, **web** (eslint/tsc/vitest), wasm+size, e2e
-3. Release: `gh release create --target ${{ github.sha }}`; `GH_TOKEN: ${{ github.token }}`
-4. wasm-opt: install recent binaryen; flags `--enable-sign-ext`, `--enable-nontrapping-float-to-int`, `--enable-simd`, `--enable-bulk-memory`
-5. Local mirror of CI left side: `npm run gate:fast`
+2. Jobs: fmt, clippy, architecture, rust, security, deny, **wasm+size** (before web), **web** (download pkg → eslint/tsc/vitest), e2e
+3. **`web/pkg` is gitignored** — never run CI `tsc` without the `wasm-pkg` artifact (harness L-001)
+4. Release: `gh release create --target ${{ github.sha }}`; `GH_TOKEN: ${{ github.token }}`
+5. wasm-opt: install recent binaryen; flags `--enable-sign-ext`, `--enable-nontrapping-float-to-int`, `--enable-simd`, `--enable-bulk-memory`
+6. Local mirror of CI left side: `npm run gate:fast` (auto-builds pkg if missing)
+7. Steering: recurring CI fail → append `agents-docs/harness.md` Learned failure modes + harden sensor
 
 ## Rust testing architecture
 

--- a/agents-docs/harness.md
+++ b/agents-docs/harness.md
@@ -104,3 +104,25 @@ Do **not** only patch product code and hope the agent remembers next time.
 - Prefer **computational** sensors for anything structural; reserve inferential for semantics and UX.
 - Sensor failure messages should tell the agent **how to fix** (see quality-gates output).
 - If a sensor never fires, suspect weak detection — not perfect quality.
+- **Local sensors must match CI assumptions** (same inputs, same missing artifacts). A green `gate:fast` that cannot fail the way CI fails is a harness bug — fix the sensor.
+
+## Learned failure modes (steering log)
+
+Append here when the same class of failure hits CI or agents twice (or once with high impact). Each entry must name the **sensor/guide change** that prevents recurrence.
+
+### L-001 — `tsc` without `web/pkg` (PR #128, 2026-07-16)
+
+| | |
+|--|--|
+| **Symptom** | CI `Web (Lint + Types + Unit)` fails: `Cannot find module './pkg/ascii_canvas.js'` |
+| **Root cause** | `web/pkg/` is **gitignored**. Local machines often have a leftover build so `gate:fast` / `tsc` pass; clean CI checkout does not. |
+| **Why harness failed** | Web job ran `tsc` in parallel with WASM build and never downloaded the `wasm-pkg` artifact. Local gate did not require pkg presence. |
+| **Prevention** | (1) CI `web` **needs** `wasm` + `download-artifact` to `web/pkg` before tsc. (2) `quality-gates.sh` builds WASM if `web/pkg` is missing before typecheck. (3) FIX hints mention gitignored pkg. |
+| **Agent rule** | Never assume `./pkg` exists after a clean clone. Before claiming web typecheck green on a machine without pkg, run `npm run build:wasm` or `gate:fast` (which ensures pkg). |
+
+### L-002 — Web-only / harness PRs skipping product sensors (pre-#128)
+
+| | |
+|--|--|
+| **Symptom** | Frontend-only PRs got no meaningful CI (path filter was Rust-only). |
+| **Prevention** | Path filters `rust` / `web` / `product` / `harness`; web + wasm + e2e wired to those outputs. |

--- a/agents-docs/harness.md
+++ b/agents-docs/harness.md
@@ -1,0 +1,106 @@
+# Agent Harness Map
+
+Mental model: **Agent = Model + Harness** ([Harness engineering](https://martinfowler.com/articles/harness-engineering.html)).
+
+This document is the inventory of **our outer harness** — everything outside the model that raises first-try success and enables self-correction before human review.
+
+## Goals of the harness
+
+1. Increase probability the agent gets it right on the first attempt (**guides / feedforward**).
+2. Let the agent detect and fix issues before humans see them (**sensors / feedback**).
+3. Keep humans focused on specification, architecture trade-offs, and behaviour that sensors cannot judge.
+
+## Control types
+
+| | **Feedforward (guides)** | **Feedback (sensors)** |
+|--|--------------------------|------------------------|
+| **Computational** | clippy/rustfmt config, `deny.toml`, typecheck configs, bootstrap scripts | `scripts/quality-gates.sh`, `scripts/check-architecture.sh`, CI, tests, size budget |
+| **Inferential** | `AGENTS.md`, skills, ADRs, architecture docs, plans | `code-review` skill, `dogfood`, `tool-validation`, human review |
+
+## Regulation categories
+
+### Maintainability
+
+| Control | Direction | Type | Location |
+|---------|-----------|------|----------|
+| Coding conventions | FF | Inferential | `AGENTS.md`, `agents-docs/best-practices.md` |
+| Rust idioms | FF | Inferential | `.agents/skills/rust-best-practices`, `rust-engineer` |
+| TypeScript standards | FF | Inferential | `.agents/skills/typescript-expert`, ADR-018 |
+| fmt / clippy / eslint / tsc | FB | Computational | quality-gates, CI |
+| LOC limit (500) | FB | Computational | quality-gates + allowlist |
+| Privacy / secret scan | FB | Computational | quality-gates |
+| cargo audit / deny | FB | Computational | CI, quality-gates full |
+| Dead-code / debt allowlist | Continuous | Computational | `.loc-allowlist` |
+
+### Architecture fitness
+
+| Control | Direction | Type | Location |
+|---------|-----------|------|----------|
+| Layer rules | FF | Inferential | `agents-docs/architecture.md` |
+| Layer import check | FB | Computational | `scripts/check-architecture.sh` |
+| WASM size ≤ 1.5MB | FB | Computational | `npm run check-size`, CI |
+| Performance notes | FF | Inferential | ADRs / TECHNICAL_ANALYSIS |
+
+### Behaviour
+
+| Control | Direction | Type | Location |
+|---------|-----------|------|----------|
+| Specs / issues / ADRs | FF | Inferential | `plans/`, GitHub issues |
+| Rust unit + integration tests | FB | Computational | `cargo test` |
+| Vitest (web) | FB | Computational | `cd web && pnpm test` |
+| Playwright E2E | FB | Computational | `npm run test:e2e` |
+| 8-tool checklist | FB | Inferential | `AGENTS.md`, `tool-validation` skill |
+| Dogfood / exploratory QA | FB | Inferential | `dogfood` skill |
+| Human acceptance | FB | Human | PR review |
+
+## Timing: keep quality left
+
+```
+Agent edit
+  → [fast sensors] fmt, clippy, cargo test, web lint/tsc/vitest, architecture, LOC
+  → self-correct loop
+  → [full sensors] wasm build, size, e2e, audit (pre-PR / CI)
+  → human review (inferential)
+  → merge → CI re-runs full sensors
+  → continuous: dependabot, allowlist debt, periodic dogfood
+```
+
+| Tier | When | Command |
+|------|------|---------|
+| **fast** | After every meaningful change; pre-commit | `npm run gate:fast` or `./scripts/quality-gates.sh --fast` |
+| **full** | Before opening PR; CI | `npm run gate:full` or `./scripts/quality-gates.sh` |
+| **tools** | UI/tool behaviour changes | `tool-validation` skill + relevant E2E |
+| **review** | Before asking human to review | `code-review` skill |
+
+## Steering loop
+
+When the **same class of failure** appears twice (agent or CI):
+
+1. Fix the immediate bug/test.
+2. **Improve the harness in the same effort** when cheap:
+   - Add a computational sensor (test, lint rule, architecture check), or
+   - Strengthen a guide (`AGENTS.md`, skill, architecture note) with the concrete rule and a self-fix hint.
+3. Log the learning in `plans/TECHNICAL_ANALYSIS.md` or a short ADR if architectural.
+
+Do **not** only patch product code and hope the agent remembers next time.
+
+## Skill → harness role
+
+| Skill | Role |
+|-------|------|
+| `goap-adr-planner` | Feedforward planning / ADRs |
+| `rust-engineer` / `rust-best-practices` / `rust-wasm` | Feedforward implementation |
+| `typescript-expert` / `vite` | Feedforward web |
+| `verify` | Computational feedback loop (run sensors, self-correct) |
+| `code-review` | Inferential feedback before human review |
+| `tool-validation` | Behaviour harness for 8 tools |
+| `dogfood` | Behaviour / UX exploratory sensor |
+| `agents-md` | Maintain harness documentation |
+| `technical-writing` | Specs and architecture docs |
+
+## Coherence rules
+
+- Guides and sensors must not contradict (e.g. AGENTS checklist must match `quality-gates` tiers and CI).
+- Prefer **computational** sensors for anything structural; reserve inferential for semantics and UX.
+- Sensor failure messages should tell the agent **how to fix** (see quality-gates output).
+- If a sensor never fires, suspect weak detection — not perfect quality.

--- a/package.json
+++ b/package.json
@@ -29,9 +29,16 @@
     "test": "cargo test && npx playwright test --project=chromium",
     "test:unit": "cargo test",
     "test:e2e": "npx playwright test",
-    "lint": "cargo clippy -- -D warnings && cargo fmt --check",
+    "test:web": "cd web && pnpm test",
+    "lint": "cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check",
+    "lint:web": "cd web && pnpm run lint && pnpm exec tsc --noEmit",
     "fmt": "cargo fmt",
-    "check-size": "size=$(stat -c%s web/pkg/ascii_canvas_bg.wasm); if [ $size -gt 1572864 ]; then echo \"WASM size $size exceeds 1.5MB limit\"; exit 1; else echo \"WASM size $size is within budget\"; fi"
+    "check-size": "size=$(stat -c%s web/pkg/ascii_canvas_bg.wasm); if [ $size -gt 1572864 ]; then echo \"WASM size $size exceeds 1.5MB limit\"; exit 1; else echo \"WASM size $size is within budget\"; fi",
+    "check:architecture": "bash scripts/check-architecture.sh",
+    "gate:fast": "bash scripts/quality-gates.sh --fast",
+    "gate:full": "bash scripts/quality-gates.sh",
+    "gate:fix": "bash scripts/quality-gates.sh --fix",
+    "precommit": "bash scripts/pre-commit-fast.sh"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/plans/ADRs/037-harness-engineering.md
+++ b/plans/ADRs/037-harness-engineering.md
@@ -1,0 +1,52 @@
+# ADR-037: Harness Engineering for Coding Agents
+
+## Status
+Accepted
+
+## Date
+2026-07-16
+
+## Context
+
+Coding agents produce non-deterministic output and lack organisational memory. This repo already has partial agent guidance (`AGENTS.md`, skills, quality-gates, CI) but the controls are uneven:
+
+- **Feedforward** (guides) is thin: root `AGENTS.md` is a checklist without architecture constraints, tiered verification, or self-correction rules.
+- **Feedback** (sensors) is incomplete on the left and in CI: web ESLint/Vitest/tsc and WASM size are not in CI; path filters ignore `web/**` so frontend-only PRs get no checks.
+- **No architecture fitness function**: layered `core → render/ui → wasm` is documented in comments but not enforced.
+- **No explicit steering loop**: recurring agent failures are not systematically promoted into guides/sensors.
+- Quality gates are all-or-nothing rather than **keep quality left** (fast local sensors vs expensive post-integration).
+
+We adopt the mental model from [Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html) (Birgitta Böckeler / martinfowler.com): **Agent = Model + Harness**, with guides + sensors that are either computational or inferential.
+
+## Decision
+
+1. **Treat the outer harness as a first-class system** documented in `agents-docs/harness.md` and driven from root `AGENTS.md`.
+2. **Organise controls by direction and execution type**:
+   - Feedforward guides: `AGENTS.md`, `agents-docs/architecture.md`, skills, ADRs
+   - Feedback sensors: `scripts/quality-gates.sh` (tiered), `scripts/check-architecture.sh`, CI, review skills
+3. **Keep quality left** with tiers:
+   - **fast** (pre-commit / agent loop): fmt, clippy, unit tests, web lint/typecheck/vitest, architecture, LOC, privacy
+   - **full** (pre-PR / CI): + WASM build, size budget, cargo audit/deny, E2E
+4. **Fix CI path filters** so `web/**`, `e2e/**`, scripts, and agent docs trigger the right jobs; add web quality and size sensors.
+5. **Architecture fitness**: computational check that `core` does not import `wasm`/`render`/`ui`; oversized files only via explicit allowlist.
+6. **Steering loop**: when the same failure happens twice, update a guide or sensor in the same change (or a follow-up PR), not only the product code.
+7. **Inferential sensors**: `code-review` and `verify` skills with LLM-oriented failure messages (positive “prompt injection” for self-correction).
+
+## Consequences
+
+### Easier
+- Agents self-correct more often before human review
+- Frontend-only changes are validated in CI
+- Clear language for maintainability vs architecture vs behaviour harnesses
+- Faster agent loops use `gate:fast` instead of full E2E every time
+
+### Harder / trade-offs
+- Harness files themselves need maintenance when conventions change
+- Known debt (`src/wasm/helpers.rs` LOC) must stay allowlisted until split
+- More CI jobs increase matrix complexity (mitigated by path filters + concurrency)
+
+## Related
+
+- `agents-docs/harness.md` — operational map of guides and sensors
+- `agents-docs/architecture.md` — architecture feedforward
+- ADR-024 (tests), ADR-018 (TS standards), ADR-021 (production readiness)

--- a/plans/ADRs/037-harness-engineering.md
+++ b/plans/ADRs/037-harness-engineering.md
@@ -47,6 +47,10 @@ We adopt the mental model from [Harness engineering for coding agent users](http
 
 ## Related
 
-- `agents-docs/harness.md` — operational map of guides and sensors
+- `agents-docs/harness.md` — operational map of guides and sensors (+ **Learned failure modes** steering log)
 - `agents-docs/architecture.md` — architecture feedforward
 - ADR-024 (tests), ADR-018 (TS standards), ADR-021 (production readiness)
+
+## Amendment (2026-07-16, PR #128 CI)
+
+**L-001**: Web TypeScript in CI requires generated `web/pkg` (gitignored). Computational sensors must either produce or download those bindings before `tsc`. Documented as a permanent steering rule: *local green / CI red on missing artifacts ⇒ fix the sensor, not only the job once.*

--- a/plans/PROJECT_STATUS.md
+++ b/plans/PROJECT_STATUS.md
@@ -81,12 +81,22 @@ A production-grade Rust/WASM ASCII diagram editor with a dark Figma-like UI.
 
 ## Immediate next steps
 
-1. **F-01** — Open PR; close #21  
-2. **F-02** — Manual multi-OS paste QA  
-3. **F-03** — Dependabot #98 / #99  
-4. **F-10 / F-11** — SVG export and layer polish when product prioritizes  
+1. **F-02** — Manual multi-OS paste QA  
+2. **F-03** — Dependabot #98 / #99  
+3. **F-10 / F-11** — SVG export and layer polish when product prioritizes  
+4. **Harness** — Adopted ADR-037 (2026-07-16): tiered gates, architecture fitness, web CI, verify/code-review skills  
 
 Full backlog: [FOLLOW_UPS.md](FOLLOW_UPS.md)
+
+### Agent harness (2026-07-16)
+
+| Piece | Location |
+|-------|----------|
+| ADR | [037-harness-engineering](ADRs/037-harness-engineering.md) |
+| Map | [agents-docs/harness.md](../agents-docs/harness.md) |
+| Fast/full sensors | `npm run gate:fast` / `gate:full` |
+| Architecture sensor | `scripts/check-architecture.sh` |
+| Skills | `verify`, `code-review` |
 
 ---
 

--- a/plans/TECHNICAL_ANALYSIS.md
+++ b/plans/TECHNICAL_ANALYSIS.md
@@ -17,6 +17,13 @@ Mapped the repo to [Harness engineering for coding agent users](https://martinfo
 
 **Debt**: split `src/wasm/helpers.rs` to leave allowlist.
 
+### Steering learning L-001 (PR #128 CI)
+
+- **Failure**: `Web` job `tsc`: `Cannot find module './pkg/ascii_canvas.js'`
+- **Cause**: gitignored `web/pkg`; CI ran tsc without WASM artifact; local gate used a pre-existing pkg
+- **Harness fix**: `web` needs `wasm` + artifact download; `quality-gates` builds pkg if missing; documented in `agents-docs/harness.md` L-001
+- **Rule**: local sensors must reproduce clean-CI inputs
+
 ## Build & Test Summary
 
 ### Build Results

--- a/plans/TECHNICAL_ANALYSIS.md
+++ b/plans/TECHNICAL_ANALYSIS.md
@@ -1,5 +1,22 @@
 # ASCII Canvas Editor - Technical Analysis
 
+## Harness engineering (2026-07-16)
+
+Mapped the repo to [Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html):
+
+| Gap found | Fix |
+|-----------|-----|
+| CI path filter only watched Rust → **web-only PRs got zero checks** | Filters: `rust`, `web`, `product`, `harness`; web job + product WASM/E2E |
+| No web ESLint/tsc/Vitest in CI | `web` job |
+| No WASM size in CI | `pnpm run check-size` on wasm job |
+| No architecture fitness sensor | `scripts/check-architecture.sh` + CI job |
+| Quality gates all-or-nothing, Rust-only | `--fast` / full tiers; web + architecture + FIX hints |
+| Thin AGENTS.md feedforward | Tiered verify, architecture rules, steering loop |
+| No review skill | `code-review` (inferential) + `verify` (computational) |
+| LOC hard-fail on known debt `helpers.rs` (708) | `.loc-allowlist` + do-not-grow policy |
+
+**Debt**: split `src/wasm/helpers.rs` to leave allowlist.
+
 ## Build & Test Summary
 
 ### Build Results

--- a/plans/action-log.md
+++ b/plans/action-log.md
@@ -6,6 +6,18 @@
 
 ---
 
+## 2026-07-16 — Harness engineering optimization
+
+- ADR-037; `agents-docs/harness.md` + `architecture.md`
+- Root `AGENTS.md` rewritten (tiered gates, steering loop)
+- `scripts/quality-gates.sh --fast|--full`; `check-architecture.sh`; `.loc-allowlist`
+- CI: web job, architecture job, size budget, fixed path filters for web/
+- Skills: `verify`, `code-review`; tool-validation frontmatter
+- package scripts: `gate:fast`, `gate:full`, `check:architecture`
+- CONTRIBUTING + PR template aligned
+
+---
+
 ## Initial Assessment
 
 ### Repository State

--- a/plans/harness-engineering-2026-07.md
+++ b/plans/harness-engineering-2026-07.md
@@ -1,0 +1,34 @@
+# Plan: Harness Engineering Optimization (2026-07-16)
+
+## Goal
+
+Increase confidence in coding-agent output by systematising **guides** (feedforward) and **sensors** (feedback) per [Harness engineering](https://martinfowler.com/articles/harness-engineering.html).
+
+## Goals (desired state)
+
+| ID | Goal |
+|----|------|
+| G1 | Agents use tiered verification (fast left, full right) |
+| G2 | CI covers Rust **and** web path changes |
+| G3 | Architecture layers enforced computationally |
+| G4 | Skills map to harness roles (verify, review, plan, implement) |
+| G5 | Steering loop documented: repeated failure → improve harness |
+
+## Actions
+
+| # | Action | Status |
+|---|--------|--------|
+| A1 | ADR-037 | done |
+| A2 | `agents-docs/harness.md` + `architecture.md` | done |
+| A3 | Rewrite root `AGENTS.md` | done |
+| A4 | Tiered `quality-gates.sh` + `check-architecture.sh` | done |
+| A5 | CI path filters, web job, size, architecture | done |
+| A6 | Skills: `verify`, `code-review` | done |
+| A7 | package.json scripts + CONTRIBUTING | done |
+| A8 | Dry-run fast gates | done (fixed vitest/config tsc) |
+
+## Non-goals
+
+- Splitting `helpers.rs` (tracked as allowlisted debt)
+- Mutation testing / full behaviour harness rewrite
+- Installing mandatory local git hooks for all contributors (script provided; optional)

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Architecture fitness sensor (computational feedback).
+# Enforces layer import rules — see agents-docs/architecture.md.
+#
+# Exit 0 = OK, Exit 1 = violation.
+# Messages are written for agent self-correction.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+FAILED=0
+
+if [[ -t 1 ]] && [[ "${FORCE_COLOR:-}" != "0" ]]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; NC=''
+fi
+
+fail() {
+  echo -e "${RED}[FAIL]${NC} $1"
+  FAILED=1
+}
+
+pass() {
+  echo -e "${GREEN}[PASS]${NC} $1"
+}
+
+# Returns matching lines of illegal imports in a directory.
+# Args: dir pattern description fix_hint
+check_forbidden_imports() {
+  local dir="$1"
+  local pattern="$2"
+  local label="$3"
+  local fix="$4"
+
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
+
+  local matches
+  matches="$(rg -n --type rust "$pattern" "$dir" 2>/dev/null || true)"
+  if [[ -n "$matches" ]]; then
+    fail "$label"
+    echo "$matches"
+    echo "  FIX: $fix"
+    echo "  See agents-docs/architecture.md"
+  fi
+}
+
+echo "Architecture fitness check..."
+echo
+
+# core → must not depend on wasm, render, ui
+check_forbidden_imports \
+  "src/core" \
+  'use crate::(wasm|render|ui)(::|;)' \
+  "src/core must not import wasm/render/ui (keep core pure)" \
+  "Move shared types into core or utils; keep WASM/render out of core."
+
+# utils → leaf: avoid pulling higher layers (and prefer not depending on core heavily)
+check_forbidden_imports \
+  "src/utils" \
+  'use crate::(wasm|render|ui)(::|;)' \
+  "src/utils must not import wasm/render/ui" \
+  "Utils must remain a leaf module."
+
+# render → no wasm, no ui
+check_forbidden_imports \
+  "src/render" \
+  'use crate::(wasm|ui)(::|;)' \
+  "src/render must not import wasm/ui" \
+  "Render may use core/utils only; put JS interop in wasm."
+
+# ui → no wasm, no render
+check_forbidden_imports \
+  "src/ui" \
+  'use crate::(wasm|render)(::|;)' \
+  "src/ui must not import wasm/render" \
+  "UI config stays free of renderer and WASM bindings."
+
+# web-sys / wasm-bindgen must not appear in core
+if [[ -d src/core ]]; then
+  matches="$(rg -n 'wasm_bindgen|web_sys|js_sys' src/core --type rust 2>/dev/null || true)"
+  if [[ -n "$matches" ]]; then
+    fail "src/core must not use wasm-bindgen/web-sys/js-sys"
+    echo "$matches"
+    echo "  FIX: Confine browser APIs to src/wasm/. Core must stay pure Rust."
+  fi
+fi
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo
+  echo "Architecture fitness FAILED. Fix layer violations before continuing."
+  exit 1
+fi
+
+pass "Layer import rules OK"
+exit 0

--- a/scripts/pre-commit-fast.sh
+++ b/scripts/pre-commit-fast.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Optional local pre-commit hook body (computational sensors, fast tier).
+# Install: ln -sf ../../scripts/pre-commit-fast.sh .git/hooks/pre-commit
+# Or run manually: ./scripts/pre-commit-fast.sh
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "$REPO_ROOT/scripts/quality-gates.sh" --fast

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -154,8 +154,26 @@ printf "\n"
 # ============================================================
 # 4. WEB CHECKS (when web/ exists)
 # ============================================================
+# LEARNING (PR #128): web/pkg is gitignored. tsc imports ./pkg/ascii_canvas.js.
+# Local trees often have a stale/cached pkg so gate:fast passes while CI fails.
+# Always require pkg bindings before typecheck (build if missing).
 if [[ -d "$REPO_ROOT/web" ]]; then
   info "Web checks (lint, typecheck, unit tests)..."
+
+  if [[ ! -f "$REPO_ROOT/web/pkg/ascii_canvas.d.ts" ]] || [[ ! -f "$REPO_ROOT/web/pkg/ascii_canvas.js" ]]; then
+    info "web/pkg missing (gitignored) — building WASM for typecheck parity with CI..."
+    if ! OUTPUT=$(pnpm run build:wasm 2>&1); then
+      fail "web/pkg / WASM build"
+      echo "  FIX: npm run build:wasm (mise: wasm-bindgen-cli 0.2.121, target wasm32-unknown-unknown)."
+      echo "  WHY: main.ts imports ./pkg/ascii_canvas.js; CI downloads wasm-pkg artifact before tsc."
+      printf "%s\n" "$OUTPUT" >&2
+    else
+      pass "WASM pkg generated for typecheck"
+    fi
+  else
+    pass "web/pkg bindings present"
+  fi
+
   pushd "$REPO_ROOT/web" >/dev/null || exit 1
 
   if [[ ! -d node_modules ]]; then
@@ -175,6 +193,7 @@ if [[ -d "$REPO_ROOT/web" ]]; then
     if ! OUTPUT=$(pnpm exec tsc --noEmit 2>&1); then
       fail "TypeScript"
       echo "  FIX: cd web && pnpm exec tsc --noEmit — fix type errors (strict mode)."
+      echo "  IF 'Cannot find module ./pkg/ascii_canvas.js': run npm run build:wasm (pkg is gitignored)."
       printf "%s\n" "$OUTPUT" >&2
     else
       pass "TypeScript: OK"

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
 # scripts/quality-gates.sh
-# Quality gate for the ASCII Canvas project.
-# Usage: ./scripts/quality-gates.sh [--fix]
+# Computational feedback sensors for the ASCII Canvas harness.
+# See agents-docs/harness.md and ADR-037.
+#
+# Usage:
+#   ./scripts/quality-gates.sh           # full tier (pre-PR / CI)
+#   ./scripts/quality-gates.sh --fast    # fast tier (agent loop / pre-commit)
+#   ./scripts/quality-gates.sh --fix    # auto-fix fmt/clippy where possible
+#   ./scripts/quality-gates.sh --fast --fix
+#
 # Exit 0 = success, Exit 1 = errors.
+# Failure lines include FIX: hints for agent self-correction.
 set +e
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
 
-readonly GIT_EXCLUDE="./.git/*"
 readonly MAX_LINES_PER_SOURCE_FILE=500
+readonly LOC_ALLOWLIST_FILE="${REPO_ROOT}/.loc-allowlist"
 
 FIX=false
+FAST=false
 for arg in "$@"; do
   case $arg in
     --fix) FIX=true ;;
-    *) echo "Unknown argument: $arg"; exit 1 ;;
+    --fast) FAST=true ;;
+    -h|--help)
+      sed -n '2,16p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg (try --fast, --fix, --help)"; exit 1 ;;
   esac
 done
 
@@ -27,11 +41,7 @@ if [[ -t 1 ]] && [[ "${FORCE_COLOR:-}" != "0" ]]; then
   BLUE='\033[0;34m'
   NC='\033[0m'
 else
-  RED=''
-  GREEN=''
-  YELLOW=''
-  BLUE=''
-  NC=''
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
 fi
 
 pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
@@ -40,149 +50,270 @@ warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 
 FAILED=0
+TIER="full"
+if $FAST; then TIER="fast"; fi
 
-printf "Running quality gate...\n\n"
+printf "Quality gates (tier=%s)...\n\n" "$TIER"
+
+is_allowlisted() {
+  local file="$1"
+  local rel="${file#./}"
+  [[ -f "$LOC_ALLOWLIST_FILE" ]] || return 1
+  grep -qxF "$rel" "$LOC_ALLOWLIST_FILE" 2>/dev/null || \
+    grep -qxF "./$rel" "$LOC_ALLOWLIST_FILE" 2>/dev/null
+}
 
 # ============================================================
 # 1. LOC LIMITS
 # ============================================================
-info "Enforcing LOC limits (max ${MAX_LINES_PER_SOURCE_FILE} lines per file)..."
+info "LOC limits (max ${MAX_LINES_PER_SOURCE_FILE}; allowlist: .loc-allowlist)..."
 LOC_VIOLATIONS=0
 while IFS= read -r file; do
-  lines=$(wc -l < "$file" 2>/dev/null || echo 0)
-  if [[ "$lines" -gt "$MAX_LINES_PER_SOURCE_FILE" ]]; then
-    warn "  $file: $lines lines (max $MAX_LINES_PER_SOURCE_FILE)"
-    LOC_VIOLATIONS=$((LOC_VIOLATIONS + 1))
+  [[ -z "$file" ]] && continue
+  lines=$(wc -l < "$file" 2>/dev/null | tr -d ' ')
+  if [[ "${lines:-0}" -gt "$MAX_LINES_PER_SOURCE_FILE" ]]; then
+    if is_allowlisted "$file"; then
+      warn "  $file: $lines lines (allowlisted debt — do not grow; extract modules)"
+    else
+      fail "  $file: $lines lines (max $MAX_LINES_PER_SOURCE_FILE)"
+      echo "  FIX: Split into smaller modules. Do not add to .loc-allowlist without an ADR."
+      LOC_VIOLATIONS=$((LOC_VIOLATIONS + 1))
+    fi
   fi
-done < <(find . -name "*.rs" -not -path "./target/*" -not -path "./.git/*" -type f 2>/dev/null)
+done < <(find ./src -name "*.rs" -type f 2>/dev/null | sort)
 
-if [[ $LOC_VIOLATIONS -gt 0 ]]; then
-  fail "LOC: $LOC_VIOLATIONS files exceed ${MAX_LINES_PER_SOURCE_FILE} lines"
-else
-  pass "LOC: All source files within limit"
+if [[ $LOC_VIOLATIONS -eq 0 ]]; then
+  pass "LOC: no new oversized files"
 fi
 printf "\n"
 
 # ============================================================
-# 2. RUST CHECKS
+# 2. ARCHITECTURE FITNESS
 # ============================================================
-info "Running Rust checks..."
+info "Architecture fitness..."
+if [[ -x "$REPO_ROOT/scripts/check-architecture.sh" ]] || [[ -f "$REPO_ROOT/scripts/check-architecture.sh" ]]; then
+  if bash "$REPO_ROOT/scripts/check-architecture.sh"; then
+    :
+  else
+    fail "Architecture: layer violations (see above)"
+    echo "  FIX: Read agents-docs/architecture.md and remove illegal imports."
+  fi
+else
+  warn "Architecture script missing"
+fi
+printf "\n"
 
-# Format
+# ============================================================
+# 3. RUST CHECKS
+# ============================================================
+info "Rust checks..."
+
 if $FIX; then
   cargo fmt --all
   pass "Format: auto-fixed"
 else
   if ! OUTPUT=$(cargo fmt --all -- --check 2>&1); then
-    fail "Format: run 'cargo fmt --all' to fix"
+    fail "Format"
+    echo "  FIX: run 'cargo fmt --all' (or ./scripts/quality-gates.sh --fix)"
     printf "%s\n" "$OUTPUT" >&2
   else
     pass "Format: OK"
   fi
 fi
 
-# Clippy
 if $FIX; then
   cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
-  pass "Clippy: auto-fixed"
+  pass "Clippy: auto-fixed (re-run without --fix to verify -D warnings)"
 else
   if ! OUTPUT=$(cargo clippy --all-targets --all-features -- -D warnings 2>&1); then
-    fail "Clippy: fix lint errors above"
+    fail "Clippy"
+    echo "  FIX: Address clippy lints. Prefer idiomatic fixes over #[allow]."
     printf "%s\n" "$OUTPUT" >&2
   else
     pass "Clippy: OK"
   fi
 fi
 
-# Build
 if ! OUTPUT=$(cargo build --all-targets 2>&1); then
-  fail "Build: failed"
+  fail "Build"
+  echo "  FIX: Fix compile errors above before continuing."
   printf "%s\n" "$OUTPUT" >&2
 else
   pass "Build: OK"
 fi
 
-# Tests
 if ! OUTPUT=$(cargo test --all 2>&1); then
-  fail "Tests: failed"
+  fail "Tests"
+  echo "  FIX: Fix failing tests; do not skip or weaken assertions to pass."
   printf "%s\n" "$OUTPUT" >&2
 else
   pass "Tests: OK"
 fi
-
-# WASM Tests (skip if wasm-bindgen-test-runner not available)
-if command -v wasm-bindgen-test-runner &>/dev/null; then
-  if ! OUTPUT=$(cargo test --all --target wasm32-unknown-unknown 2>&1); then
-    fail "WASM Tests: failed"
-    printf "%s\n" "$OUTPUT" >&2
-  else
-    pass "WASM Tests: OK"
-  fi
-else
-  warn "WASM Tests: skipped (wasm-bindgen-test-runner not found)"
-fi
 printf "\n"
 
 # ============================================================
-# 3. SECURITY AUDIT
+# 4. WEB CHECKS (when web/ exists)
 # ============================================================
-if command -v cargo-audit &>/dev/null; then
-  info "Running security audit..."
-  AUDIT_OUTPUT=$(cargo audit 2>&1) && AUDIT_EXIT=$? || AUDIT_EXIT=$?
-  if [ $AUDIT_EXIT -ne 0 ]; then
-    if echo "$AUDIT_OUTPUT" | grep -q "unsupported CVSS version"; then
-      warn "cargo-audit: Skipping due to RustSec advisory format issue"
+if [[ -d "$REPO_ROOT/web" ]]; then
+  info "Web checks (lint, typecheck, unit tests)..."
+  pushd "$REPO_ROOT/web" >/dev/null || exit 1
+
+  if [[ ! -d node_modules ]]; then
+    warn "web/node_modules missing — running pnpm install"
+    pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+  fi
+
+  if ! OUTPUT=$(pnpm run lint 2>&1); then
+    fail "ESLint"
+    echo "  FIX: cd web && pnpm run lint — fix reported issues."
+    printf "%s\n" "$OUTPUT" >&2
+  else
+    pass "ESLint: OK"
+  fi
+
+  if command -v pnpm >/dev/null && pnpm exec tsc --version >/dev/null 2>&1; then
+    if ! OUTPUT=$(pnpm exec tsc --noEmit 2>&1); then
+      fail "TypeScript"
+      echo "  FIX: cd web && pnpm exec tsc --noEmit — fix type errors (strict mode)."
+      printf "%s\n" "$OUTPUT" >&2
     else
-      fail "Security audit: vulnerabilities found"
+      pass "TypeScript: OK"
     fi
   else
-    pass "Audit: OK"
+    warn "tsc not available; skipped typecheck"
   fi
+
+  if ! OUTPUT=$(pnpm test 2>&1); then
+    fail "Vitest"
+    echo "  FIX: cd web && pnpm test — fix unit tests."
+    printf "%s\n" "$OUTPUT" >&2
+  else
+    pass "Vitest: OK"
+  fi
+
+  popd >/dev/null || true
   printf "\n"
 fi
 
 # ============================================================
-# 4. PRIVACY CHECK (No emails)
+# 5. PRIVACY + SECRETS (fast + full)
 # ============================================================
-info "Checking for email addresses (privacy-first)..."
+info "Privacy (no real emails)..."
 EMAIL_PATTERN='[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
-EXCLUDE_PATTERN='example\.com|example\.org|test\.com|\.git|target|\.opencode|\.mimocode|\.md|references'
+EXCLUDE_PATTERN='example\.com|example\.org|test\.com|\.git|target|\.opencode|\.mimocode|node_modules|playwright-report|test-results|\.md|references|agents-docs|\.agents'
 
 if grep -rE "$EMAIL_PATTERN" \
   --exclude-dir=.git --exclude-dir=target --exclude-dir=.opencode --exclude-dir=.mimocode \
-  --exclude-dir=references \
+  --exclude-dir=node_modules --exclude-dir=references --exclude-dir=playwright-report \
+  --exclude-dir=test-results --exclude-dir=.agents \
   . 2>/dev/null | grep -vE "$EXCLUDE_PATTERN"; then
-  fail "Email address detected in codebase"
+  fail "Email address detected"
+  echo "  FIX: Remove personal emails; use example.com placeholders."
 else
   pass "Privacy: OK"
 fi
 printf "\n"
 
-# ============================================================
-# 5. SECRET SCAN
-# ============================================================
-info "Scanning for potential secrets..."
+info "Secret scan..."
 SECRET_PATTERN="(api_key|token|secret|password|auth|key)[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-]{16,}['\"]"
-EXCLUDE_DIR='--exclude-dir=.git --exclude-dir=target --exclude-dir=.agents --exclude-dir=.opencode'
 EXCLUDE_SECRET='example\.com|example\.org|test\.com|GITHUB_TOKEN|CARGO_REGISTRY_TOKEN|worktree|shared-key|release-workflow'
 
-if grep -rE "$SECRET_PATTERN" $EXCLUDE_DIR . 2>/dev/null | grep -vE "$EXCLUDE_SECRET"; then
-  fail "Potential secret detected in codebase"
+if grep -rE "$SECRET_PATTERN" \
+  --exclude-dir=.git --exclude-dir=target --exclude-dir=.agents --exclude-dir=.opencode \
+  --exclude-dir=node_modules --exclude-dir=playwright-report --exclude-dir=test-results \
+  . 2>/dev/null | grep -vE "$EXCLUDE_SECRET"; then
+  fail "Potential secret detected"
+  echo "  FIX: Remove secrets; use env vars / GitHub Actions secrets."
 else
-  pass "Secret Scan: OK"
+  pass "Secret scan: OK"
 fi
 printf "\n"
+
+# ============================================================
+# 6. FULL-ONLY: security, WASM, size, E2E
+# ============================================================
+if ! $FAST; then
+  if command -v cargo-audit &>/dev/null; then
+    info "Security audit..."
+    AUDIT_OUTPUT=$(cargo audit 2>&1) && AUDIT_EXIT=$? || AUDIT_EXIT=$?
+    if [ "$AUDIT_EXIT" -ne 0 ]; then
+      if echo "$AUDIT_OUTPUT" | grep -q "unsupported CVSS version"; then
+        warn "cargo-audit: skipped (advisory format issue)"
+      else
+        fail "Security audit"
+        echo "  FIX: Review cargo audit output; update or yank vulnerable crates."
+        printf "%s\n" "$AUDIT_OUTPUT" >&2
+      fi
+    else
+      pass "Audit: OK"
+    fi
+    printf "\n"
+  else
+    warn "cargo-audit not installed (CI runs it)"
+  fi
+
+  if command -v cargo-deny &>/dev/null; then
+    info "cargo-deny..."
+    if ! OUTPUT=$(cargo deny check 2>&1); then
+      fail "cargo-deny"
+      echo "  FIX: Align dependencies with deny.toml licenses/sources."
+      printf "%s\n" "$OUTPUT" >&2
+    else
+      pass "cargo-deny: OK"
+    fi
+    printf "\n"
+  fi
+
+  info "WASM build + size..."
+  if ! OUTPUT=$(pnpm run build:wasm 2>&1); then
+    fail "WASM build"
+    echo "  FIX: Ensure rustup target wasm32-unknown-unknown and wasm-bindgen-cli 0.2.121 (mise.toml)."
+    printf "%s\n" "$OUTPUT" >&2
+  else
+    pass "WASM build: OK"
+    if ! OUTPUT=$(pnpm run check-size 2>&1); then
+      fail "WASM size"
+      echo "  FIX: Reduce binary size (opt-level z already on); avoid heavy deps in wasm path."
+      printf "%s\n" "$OUTPUT" >&2
+    else
+      pass "WASM size: OK"
+      printf "%s\n" "$OUTPUT"
+    fi
+  fi
+  printf "\n"
+
+  info "E2E (Playwright chromium)..."
+  if [[ ! -d "$REPO_ROOT/node_modules" ]]; then
+    pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+  fi
+  if ! OUTPUT=$(npx playwright test --project=chromium 2>&1); then
+    fail "E2E"
+    echo "  FIX: Inspect Playwright report; fix product or test. Prefer POM helpers over waits."
+    printf "%s\n" "$OUTPUT" >&2
+  else
+    pass "E2E: OK"
+  fi
+  printf "\n"
+else
+  info "Skipping full-tier sensors (WASM, size, E2E, audit). Run without --fast before PR."
+  printf "\n"
+fi
 
 # ============================================================
 # SUMMARY
 # ============================================================
 if [[ $FAILED -ne 0 ]]; then
   printf "${RED}─────────────────────────────────────────────────────────────────${NC}\n"
-  printf "${RED}│ Quality Gate FAILED                                           │${NC}\n"
+  printf "${RED}│ Quality Gate FAILED (tier=%s)%*s│${NC}\n" "$TIER" $((40 - ${#TIER})) ""
+  printf "${RED}│ Self-correct using FIX: hints above, then re-run.             │${NC}\n"
   printf "${RED}─────────────────────────────────────────────────────────────────${NC}\n"
   exit 1
 fi
 
 printf "${GREEN}─────────────────────────────────────────────────────────────────${NC}\n"
-printf "${GREEN}│ All Quality Gates PASSED                                      │${NC}\n"
+printf "${GREEN}│ All quality gates PASSED (tier=%s)%*s│${NC}\n" "$TIER" $((37 - ${#TIER})) ""
 printf "${GREEN}─────────────────────────────────────────────────────────────────${NC}\n"
+if $FAST; then
+  printf "Next: npm run gate:full before opening a PR.\n"
+fi
+exit 0

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   root: '.',


### PR DESCRIPTION
## Summary

Adopts [Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html) as the outer agent harness: **guides (feedforward)** + **sensors (feedback)**, tiered left-to-right, with a steering loop when failures recur.

- **Guides**: Rewrote `AGENTS.md`; added `agents-docs/harness.md`, `architecture.md`, ADR-037
- **Sensors**: Tiered `npm run gate:fast` / `gate:full`, architecture fitness script, LOC allowlist
- **CI**: Path filters for rust/web/product/harness; web job (eslint/tsc/vitest); architecture job; WASM size budget; web-only PRs no longer skip checks
- **Skills**: `verify` (computational), `code-review` (inferential); tool-validation harness link
- **Fix**: `web/vite.config.ts` uses `vitest/config` so strict `tsc` passes

## Changes made

- CI path filters + new jobs (`architecture`, `web`)
- `scripts/quality-gates.sh --fast|--full` with agent-oriented `FIX:` hints
- `scripts/check-architecture.sh` + `.loc-allowlist`
- CONTRIBUTING, PR template, README, plans status docs
- Known debt: `src/wasm/helpers.rs` remain allowlisted (do not grow)

## Testing (harness)

- [x] Fast gates: `npm run gate:fast` (fmt, clippy, tests, architecture, web lint/tsc/vitest)
- [ ] Full gates (if product behaviour): `npm run gate:full` (WASM, size, E2E) — not required for harness-only product paths; CI will run product/harness jobs
- [ ] Or equivalent CI jobs green

## Checklist

- [x] Read CONTRIBUTING / AGENTS
- [x] Architecture layers respected (sensor enforces)
- [x] ADR-037 + harness docs updated
- [x] Recurring gap (web CI blind spot) fixed with sensors, not only docs

## Related issues

N/A — process/infra hardening from harness-engineering article comparison.