### PR TITLE
build(deps): Triage wasm-bindgen 0.2.121 -> 0.2.126 (F-03)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ core (pure) ← render, ui ← wasm ← web/
 
 ## Web / WASM
 
-- Build WASM: `npm run build:wasm` (wasm-bindgen **0.2.121**, see `mise.toml`).
+- Build WASM: `npm run build:wasm` (wasm-bindgen **0.2.126**, see `mise.toml`).
 - Web lint/test: `cd web && pnpm lint && pnpm exec tsc --noEmit && pnpm test`.
 - E2E: Playwright from repo root; prefer `--project=chromium` locally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing!
 
 - Rust (stable) with target `wasm32-unknown-unknown`
 - Node.js 22+ and pnpm 10
-- [mise](https://mise.jdx.dev/) recommended (`mise.toml` pins wasm-bindgen-cli **0.2.121** and binaryen)
+- [mise](https://mise.jdx.dev/) recommended (`mise.toml` pins wasm-bindgen-cli **0.2.126** and binaryen)
 
 ### Quick start
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/d-o-hub/rust-ascii-canvas"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.121"
+wasm-bindgen = "=0.2.126"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 rust = { version = "stable", targets = "wasm32-unknown-unknown" }
 node = "22"
-"cargo:wasm-bindgen-cli" = "0.2.121"
+"cargo:wasm-bindgen-cli" = "0.2.126"
 "github:WebAssembly/binaryen" = "latest"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:wasm": "cargo build --target wasm32-unknown-unknown --release && wasm-bindgen target/wasm32-unknown-unknown/release/ascii_canvas.wasm --out-dir web/pkg --target web && (command -v wasm-opt >/dev/null && wasm-opt --enable-simd --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -O3 web/pkg/ascii_canvas_bg.wasm -o web/pkg/ascii_canvas_bg.wasm || echo 'wasm-opt not found; skipping optimization')",
     "build:web": "cd web && pnpm run build",
     "build": "pnpm run build:wasm && pnpm run build:web",
-    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.121 && npm install -g wasm-opt && pnpm install --frozen-lockfile && cd web && pnpm install --frozen-lockfile && cd .. && pnpm run build && pnpm run check-size",
+    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.126 && npm install -g wasm-opt && pnpm install --frozen-lockfile && cd web && pnpm install --frozen-lockfile && cd .. && pnpm run build && pnpm run check-size",
     "dev": "cd web && pnpm run dev",
     "test": "cargo test && npx playwright test --project=chromium",
     "test:unit": "cargo test",

--- a/plans/PROJECT_STATUS.md
+++ b/plans/PROJECT_STATUS.md
@@ -18,7 +18,7 @@ A production-grade Rust/WASM ASCII diagram editor with a dark Figma-like UI.
 | Item | Value |
 |------|--------|
 | Version | 0.1.1 |
-| WASM toolchain | cargo + wasm-bindgen **0.2.121** |
+| WASM toolchain | cargo + wasm-bindgen **0.2.126** |
 | Target | `wasm32-unknown-unknown` / ES modules |
 | Rust | stable |
 | WASM size budget | ≤ 1.5MB (`npm run check-size`) |

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -164,7 +164,7 @@ if [[ -d "$REPO_ROOT/web" ]]; then
     info "web/pkg missing (gitignored) — building WASM for typecheck parity with CI..."
     if ! OUTPUT=$(pnpm run build:wasm 2>&1); then
       fail "web/pkg / WASM build"
-      echo "  FIX: npm run build:wasm (mise: wasm-bindgen-cli 0.2.121, target wasm32-unknown-unknown)."
+      echo "  FIX: npm run build:wasm (mise: wasm-bindgen-cli 0.2.126, target wasm32-unknown-unknown)."
       echo "  WHY: main.ts imports ./pkg/ascii_canvas.js; CI downloads wasm-pkg artifact before tsc."
       printf "%s\n" "$OUTPUT" >&2
     else
@@ -286,7 +286,7 @@ if ! $FAST; then
   info "WASM build + size..."
   if ! OUTPUT=$(pnpm run build:wasm 2>&1); then
     fail "WASM build"
-    echo "  FIX: Ensure rustup target wasm32-unknown-unknown and wasm-bindgen-cli 0.2.121 (mise.toml)."
+    echo "  FIX: Ensure rustup target wasm32-unknown-unknown and wasm-bindgen-cli 0.2.126 (mise.toml)."
     printf "%s\n" "$OUTPUT" >&2
   else
     pass "WASM build: OK"


### PR DESCRIPTION
Upgraded wasm-bindgen and its matching wasm-bindgen-cli to version 0.2.126. Addressed Dependabot PR #99 / follow-up issue F-03 by consistently bumping dependencies and updating all local dev tool versions, CI setup, Netlify build tasks, quality gate sensors, and documentation. Full testing, including cargo native/wasm tests, Vitest, and Playwright E2E chromium tests, passes successfully.

Fixes #109

---
*PR created automatically by Jules for task [18273220792157054651](https://jules.google.com/task/18273220792157054651) started by @d-o-hub*