### PR TITLE
Remove `#![allow(missing_docs)]` from WASM modules and document public API

### DIFF
--- a/src/wasm/bindings.rs
+++ b/src/wasm/bindings.rs
@@ -1,7 +1,5 @@
 //! WASM bindings - struct definition, constructor, and core methods.
 
-#![allow(missing_docs)]
-
 use crate::core::history::History;
 use crate::core::selection::{Selection, SelectionClipboard};
 use crate::core::tools::{DrawOp, RectangleTool, Tool, ToolId};
@@ -12,6 +10,11 @@ use crate::wasm::tool_manager::{
 };
 use wasm_bindgen::prelude::*;
 
+/// WebAssembly-bindable ASCII editor instance for frontend integration.
+///
+/// `AsciiEditor` manages the state of the ASCII canvas, handles user interactions,
+/// renders grid content to JSON / canvas drawing commands, and supports history
+/// (undo/redo) and layer capabilities.
 #[wasm_bindgen]
 pub struct AsciiEditor {
     pub(crate) state: EditorState,
@@ -50,6 +53,7 @@ pub(crate) struct LayerData {
 
 #[wasm_bindgen]
 impl AsciiEditor {
+    /// Creates a new `AsciiEditor` instance with the given dimensions.
     #[wasm_bindgen(constructor)]
     pub fn new(width: usize, height: usize) -> Self {
         let state = EditorState::new(width, height);
@@ -85,6 +89,7 @@ impl AsciiEditor {
         }
     }
 
+    /// Resizes the editor canvas and all its layers to the new dimensions.
     #[wasm_bindgen]
     pub fn resize(&mut self, new_width: usize, new_height: usize) {
         self.state.grid.resize(new_width, new_height);
@@ -95,21 +100,25 @@ impl AsciiEditor {
         self.dirty_tracker.request_full_redraw();
     }
 
+    /// Gets the current width of the canvas grid.
     #[wasm_bindgen(getter)]
     pub fn width(&self) -> usize {
         self.state.grid.width()
     }
 
+    /// Gets the current height of the canvas grid.
     #[wasm_bindgen(getter)]
     pub fn height(&self) -> usize {
         self.state.grid.height()
     }
 
+    /// Gets the name of the active drawing tool.
     #[wasm_bindgen(getter)]
     pub fn tool(&self) -> String {
         self.tool_id.name().to_string()
     }
 
+    /// Sets the active tool by its string ID.
     #[wasm_bindgen(js_name = setTool)]
     pub fn set_tool(&mut self, tool_id: String) {
         if let Some(id) = parse_tool_id(&tool_id) {
@@ -124,6 +133,8 @@ impl AsciiEditor {
         }
     }
 
+    /// Attempts to set the active tool using a keyboard shortcut character.
+    /// Returns true if the shortcut is valid and the tool was switched.
     #[wasm_bindgen(js_name = setToolByShortcut)]
     pub fn set_tool_by_shortcut(&mut self, shortcut: char) -> bool {
         if let Some(id) = ToolId::from_shortcut(shortcut) {
@@ -141,39 +152,46 @@ impl AsciiEditor {
         }
     }
 
+    /// Sets the border style for shapes like Rectangles.
     #[wasm_bindgen(js_name = setBorderStyle)]
     pub fn set_border_style(&mut self, style: String) {
         set_border_style(&mut self.state, style, &mut self.active_tool);
     }
 
+    /// Sets the line direction setting (e.g. Horizontal, Vertical, Auto) for the Line tool.
     #[wasm_bindgen(js_name = setLineDirection)]
     pub fn set_line_direction(&mut self, direction: String) {
         set_line_direction(self.tool_id, &mut self.active_tool, direction);
     }
 
+    /// Sets the zoom scale factor of the editor viewport.
     #[wasm_bindgen(js_name = setZoom)]
     pub fn set_zoom(&mut self, zoom: f64) {
         self.renderer.set_zoom(zoom);
         self.dirty_tracker.request_full_redraw();
     }
 
+    /// Gets the current zoom scale factor of the editor viewport.
     #[wasm_bindgen(getter)]
     pub fn zoom(&self) -> f64 {
         self.renderer.zoom()
     }
 
+    /// Sets the pan offset (X and Y coordinates) of the editor viewport.
     #[wasm_bindgen(js_name = setPan)]
     pub fn set_pan(&mut self, x: f64, y: f64) {
         self.renderer.set_pan(x, y);
         self.dirty_tracker.request_full_redraw();
     }
 
+    /// Gets the current pan offset of the editor viewport as a `[x, y]` list.
     #[wasm_bindgen(getter = pan)]
     pub fn get_pan(&self) -> Vec<f64> {
         let (x, y) = self.renderer.pan();
         vec![x, y]
     }
 
+    /// Configures the font metrics for text size and grid layout spacing calculations.
     #[wasm_bindgen(js_name = setFontMetrics)]
     pub fn set_font_metrics(&mut self, char_width: f64, line_height: f64, size: f64) {
         let mut metrics = FontMetrics::new("JetBrains Mono, monospace", size);
@@ -183,6 +201,7 @@ impl AsciiEditor {
         self.dirty_tracker.request_full_redraw();
     }
 
+    /// Reverts the last drawing operation. Returns true if successful.
     #[wasm_bindgen]
     pub fn undo(&mut self) -> bool {
         let result = self.history.undo(&mut self.state.grid);
@@ -192,6 +211,7 @@ impl AsciiEditor {
         result
     }
 
+    /// Re-applies a previously undone operation. Returns true if successful.
     #[wasm_bindgen]
     pub fn redo(&mut self) -> bool {
         let result = self.history.redo(&mut self.state.grid);
@@ -201,16 +221,19 @@ impl AsciiEditor {
         result
     }
 
+    /// Returns whether there is an action that can be undone in the history.
     #[wasm_bindgen(getter)]
     pub fn can_undo(&self) -> bool {
         self.history.can_undo()
     }
 
+    /// Returns whether there is an action that can be redone in the history.
     #[wasm_bindgen(getter)]
     pub fn can_redo(&self) -> bool {
         self.history.can_redo()
     }
 
+    /// Clears the canvas, history, clipboard, and reset layers.
     #[wasm_bindgen]
     pub fn clear(&mut self) {
         self.state.grid.clear();

--- a/src/wasm/event_handlers.rs
+++ b/src/wasm/event_handlers.rs
@@ -1,7 +1,5 @@
 //! Pointer, keyboard, and wheel event handlers for WASM.
 
-#![allow(missing_docs)]
-
 use wasm_bindgen::prelude::*;
 
 use super::bindings::AsciiEditor;
@@ -9,6 +7,7 @@ use crate::core::tools::ToolId;
 
 #[wasm_bindgen]
 impl AsciiEditor {
+    /// Handles pointer/mouse down events and triggers tool action starts.
     #[wasm_bindgen(js_name = onPointerDown)]
     pub fn on_pointer_down(&mut self, screen_x: f64, screen_y: f64) -> JsValue {
         if self.space_held {
@@ -50,6 +49,7 @@ impl AsciiEditor {
         self.js_event_result()
     }
 
+    /// Handles pointer/mouse move events for drawing previews, panning, or moving selections.
     #[wasm_bindgen(js_name = onPointerMove)]
     pub fn on_pointer_move(&mut self, screen_x: f64, screen_y: f64) -> JsValue {
         if self.is_panning {
@@ -90,6 +90,7 @@ impl AsciiEditor {
         self.js_event_result()
     }
 
+    /// Handles pointer/mouse up events to commit drawing actions or selection modifications.
     #[wasm_bindgen(js_name = onPointerUp)]
     pub fn on_pointer_up(&mut self, screen_x: f64, screen_y: f64) -> JsValue {
         if self.is_panning {
@@ -120,6 +121,7 @@ impl AsciiEditor {
         self.js_event_result()
     }
 
+    /// Handles keyboard key down events for shortcuts, copy/paste, backspace/delete, etc.
     #[wasm_bindgen(js_name = onKeyDown)]
     pub fn on_key_down(&mut self, key: String, ctrl: bool, shift: bool) -> JsValue {
         let key_char = if key.len() == 1 {
@@ -218,6 +220,7 @@ impl AsciiEditor {
         self.js_event_result()
     }
 
+    /// Handles keyboard key up events (e.g. releasing spacebar to stop panning).
     #[wasm_bindgen(js_name = onKeyUp)]
     pub fn on_key_up(&mut self, key: String) {
         if key == " " {
@@ -226,6 +229,7 @@ impl AsciiEditor {
         }
     }
 
+    /// Handles mouse wheel zoom and pan operations.
     #[wasm_bindgen(js_name = onWheel)]
     pub fn on_wheel(&mut self, delta: f64, screen_x: f64, screen_y: f64) -> JsValue {
         let zoom_factor = if delta > 0.0 { 0.9 } else { 1.1 };

--- a/src/wasm/render_api.rs
+++ b/src/wasm/render_api.rs
@@ -1,7 +1,5 @@
 //! Rendering and pixel buffer API for WASM.
 
-#![allow(missing_docs)]
-
 use wasm_bindgen::prelude::*;
 
 use super::bindings::AsciiEditor;
@@ -12,6 +10,7 @@ use crate::wasm::render_bridge::{
 
 #[wasm_bindgen]
 impl AsciiEditor {
+    /// Exports the composited visible canvas layers as a raw ASCII text string.
     #[wasm_bindgen(js_name = exportAscii)]
     pub fn export_ascii(&self) -> String {
         // Composite all visible layers so export matches what users expect from multi-layer docs.
@@ -92,6 +91,7 @@ impl AsciiEditor {
         }
     }
 
+    /// Returns the full list of drawing instructions/commands to render the entire canvas in JS.
     #[wasm_bindgen(js_name = getRenderCommands)]
     pub fn get_render_commands(&mut self) -> JsValue {
         self.full_render_count += 1;
@@ -110,6 +110,7 @@ impl AsciiEditor {
         }
     }
 
+    /// Returns only the drawing instructions/commands for regions of the canvas that have changed.
     #[wasm_bindgen(js_name = getDirtyRenderCommands)]
     pub fn get_dirty_render_commands(&mut self) -> JsValue {
         if self.dirty_tracker.needs_full_redraw() {
@@ -125,37 +126,44 @@ impl AsciiEditor {
         )
     }
 
+    /// Returns the number of times a full render was requested and executed.
     #[wasm_bindgen(getter = fullRenderCount)]
     pub fn full_render_count(&self) -> u32 {
         self.full_render_count
     }
 
+    /// Returns the number of times a partial/dirty rect render was requested and executed.
     #[wasm_bindgen(getter = dirtyRenderCount)]
     pub fn dirty_render_count(&self) -> u32 {
         self.dirty_render_count
     }
 
+    /// Resets full and dirty render performance metric counters to zero.
     #[wasm_bindgen(js_name = resetPerformanceMetrics)]
     pub fn reset_performance_metrics(&mut self) {
         self.full_render_count = 0;
         self.dirty_render_count = 0;
     }
 
+    /// Returns whether the canvas currently needs to be redrawn.
     #[wasm_bindgen(getter = needsRedraw)]
     pub fn needs_redraw(&self) -> bool {
         needs_redraw(&self.dirty_tracker)
     }
 
+    /// Explicitly flags that the entire canvas needs to be redrawn on the next frame.
     #[wasm_bindgen(js_name = requestRedraw)]
     pub fn request_redraw(&mut self) {
         request_full_redraw(&mut self.dirty_tracker);
     }
 
+    /// Resets the dirty rendering rect and flag status.
     #[wasm_bindgen(js_name = clearDirtyState)]
     pub fn clear_dirty_state(&mut self) {
         self.dirty_tracker.clear();
     }
 
+    /// Updates the font atlas glyph data cache for a specific Unicode character.
     #[wasm_bindgen(js_name = updateFontAtlasGlyph)]
     pub fn update_font_atlas_glyph(&mut self, ch_code: u32, glyph_data: Vec<u8>) {
         if let Some(ch) = char::from_u32(ch_code) {
@@ -164,16 +172,19 @@ impl AsciiEditor {
         }
     }
 
+    /// Returns the pointer to the underlying raw pixel buffer (RGBA format).
     #[wasm_bindgen(js_name = getPixelBufferPtr)]
     pub fn get_pixel_buffer_ptr(&self) -> *const u8 {
         self.pixel_buffer.as_ptr()
     }
 
+    /// Returns the length of the raw pixel buffer in bytes.
     #[wasm_bindgen(js_name = getPixelBufferLen)]
     pub fn get_pixel_buffer_len(&self) -> usize {
         self.pixel_buffer.len()
     }
 
+    /// Renders the entire canvas layers and current selection highlights into the pixel buffer.
     #[wasm_bindgen(js_name = renderToPixelBuffer)]
     pub fn render_to_pixel_buffer(&mut self) {
         let grid_width = self.state.grid.width();

--- a/src/wasm/selection.rs
+++ b/src/wasm/selection.rs
@@ -1,43 +1,52 @@
 //! Selection, clipboard, and move operations for WASM.
 
-#![allow(missing_docs)]
-
 use wasm_bindgen::prelude::*;
 
 use super::bindings::AsciiEditor;
 
 #[wasm_bindgen]
 impl AsciiEditor {
+    /// Selects the entire canvas area.
     #[wasm_bindgen(js_name = selectAll)]
     pub fn select_all(&mut self) {
         self.select_all_impl();
     }
 
+    /// Copies the active selection or the full grid content to the internal clipboard.
+    /// Returns true if something was copied.
     #[wasm_bindgen(js_name = copySelection)]
     pub fn copy_selection(&mut self) -> bool {
         self.copy_selection_impl()
     }
 
+    /// Cuts the active selection from the canvas and places it on the internal clipboard.
+    /// Returns true if successful.
     #[wasm_bindgen(js_name = cutSelection)]
     pub fn cut_selection(&mut self) -> bool {
         self.cut_selection_impl()
     }
 
+    /// Pastes content from the internal clipboard onto the active canvas.
+    /// Returns true if successful.
     #[wasm_bindgen]
     pub fn paste(&mut self) -> bool {
         self.paste_impl()
     }
 
+    /// Deletes the currently selected area, replacing cell content with spaces.
+    /// Returns true if successful.
     #[wasm_bindgen(js_name = deleteSelection)]
     pub fn delete_selection(&mut self) -> bool {
         self.delete_selection_impl()
     }
 
+    /// Returns whether the internal editor clipboard contains any elements.
     #[wasm_bindgen(getter)]
     pub fn has_clipboard(&self) -> bool {
         !self.clipboard.is_empty()
     }
 
+    /// Returns whether there is an active selection region on the canvas.
     #[wasm_bindgen(getter)]
     pub fn has_selection(&self) -> bool {
         self.current_selection.is_some()


### PR DESCRIPTION
This PR removes the module-level `#![allow(missing_docs)]` attributes from all Rust WebAssembly binding modules (`src/wasm/bindings.rs`, `src/wasm/event_handlers.rs`, `src/wasm/render_api.rs`, and `src/wasm/selection.rs`). To ensure clean documentation compilation with the workspace-wide `#![warn(missing_docs)]` directive, detailed doc comments have been added for the public `AsciiEditor` struct and all of its exported methods, constructors, and getters. All tests and documentation generation (`cargo doc`) compile cleanly without any warnings.

Fixes #121

---
*PR created automatically by Jules for task [9236640541202622281](https://jules.google.com/task/9236640541202622281) started by @d-o-hub*