### PR TITLE
Configure Firefox and WebKit CI E2E & Mobile Skip Policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
         run: pnpm test
 
   e2e:
-    name: E2E Tests (Playwright)
+    name: E2E Tests (Playwright) - ${{ matrix.project }}
     runs-on: ubuntu-latest
     needs: [changes, wasm]
     if: >
@@ -312,6 +312,10 @@ jobs:
        needs.changes.outputs.harness == 'true') &&
       needs.wasm.result == 'success'
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [chromium, firefox, webkit]
 
     steps:
       - name: Checkout code
@@ -341,7 +345,7 @@ jobs:
           cd web && pnpm install --frozen-lockfile
 
       - name: Install Playwright
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install ${{ matrix.project }} --with-deps
 
       - name: Download WASM
         uses: actions/download-artifact@v8
@@ -362,7 +366,7 @@ jobs:
             sleep 1
           done
           cd ..
-          npx playwright test --project=chromium --timeout=90000
+          npx playwright test --project=${{ matrix.project }} --timeout=120000
         env:
           CI: true
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,67 @@
+# ASCII Canvas Editor - End-to-End (E2E) Testing Architecture
+
+This directory contains Playwright-driven end-to-end tests designed to verify the correct functionality, performance, and cross-browser consistency of the ASCII Canvas Editor.
+
+## Directory Structure
+
+- `canvas.spec.ts` — Verifies core canvas load states, basic tool selections, border styles, status bar info, and simple drawing operations.
+- `clipboard.spec.ts` — Focuses on clipboard operations, selection-aware ASCII export fidelity, CRLF line endings, and document save/load round-tripping.
+- `responsive.spec.ts` — Checks responsive grid resizing across mobile, tablet, and desktop viewports, ensuring edge-drawing works correctly.
+- `tools-drawing.spec.ts` — Validates drawing with each of the 8 tools (Rectangle, Line, Arrow, Diamond, Text, Freehand, Select, Eraser), shape moving, select deletes, and edge cases.
+- `helpers.ts` — Common utility functions like `openEditor` and `clearAutosave`.
+
+---
+
+## Browser Testing Matrix
+
+We support and test the following browser configurations across multiple viewports:
+
+| Project Name | Browser Engine | Device / Viewport Profile | Screen Width | Purpose |
+|---|---|---|---|---|
+| **chromium** | Chromium | Desktop Chrome | 1280x720 | Main production desktop target |
+| **firefox** | Firefox | Desktop Firefox | 1280x720 | Cross-browser compatibility |
+| **webkit** | WebKit (Safari) | Desktop Safari | 1280x720 | macOS/iOS layout compatibility |
+| **mobile-chrome** | Chromium | Pixel 5 | 393x851 | Responsive layout & touch interactions |
+| **mobile-safari** | WebKit | iPhone 12 | 390x844 | Mobile Apple ecosystem rendering |
+| **tablet-safari** | WebKit | iPad Air | 820x1180 | Medium form-factor touch interactions |
+
+---
+
+## Flake Budget and Retry Strategy
+
+End-to-End tests in browser environments are inherently vulnerable to transient flakes due to asynchronous rendering, network latency, or container resource constraints. To maintain high reliability and a strict "flake budget":
+
+1. **Automatic Retries**:
+   - **Continuous Integration (CI)**: Configured with `retries: 1` inside `playwright.config.ts`. This absorbs single-occurrence rendering delays or dev server warmup flakes.
+   - **Local Development**: Configured with `retries: 0` so that any functional issues are highlighted immediately.
+
+2. **Timeout Boundaries**:
+   - **Test Timeout**: 60 seconds (`timeout: 60000`).
+   - **Assertion Timeout**: 10 seconds (`expect: { timeout: 10000 }`).
+   - **Action Timeout**: 30 seconds (`actionTimeout: 30000`).
+   - **CI Web Dev Server Warmup**: Up to 60 seconds to guarantee Vite is fully compiled and ready on port 3003.
+
+3. **Flake Mitigation Practices**:
+   - Avoid `waitForTimeout()`. Instead, use state-based assertions like `expect().toBeVisible()` or `page.waitForFunction()`.
+   - Wait for the WASM module to initialize fully via `window.editor !== null` before performing user actions.
+   - Reset the storage state before every test via `clearAutosave()` to guarantee tests start from a pristine canvas state.
+
+---
+
+## Mobile Skip Policy
+
+The ASCII Canvas Editor uses a highly responsive CSS grid design. On viewports with width $\le$ 768px (which includes the `mobile-chrome` and `mobile-safari` profiles), the following visual sections are hidden to optimize smaller screens:
+- **Side Panel** (`.side-panel`) — Zoom indicators, Grid size inputs, Layers, and the Shortcuts list.
+- **Toolbar Left/Right** (`.toolbar-left`, `.toolbar-right`) — Logo, Undo/Redo, Copy, Save, Load, PNG export, Clear Canvas, and Help buttons.
+- **Status Bar** (`.status-bar`) — Active tool description and dynamic status toasts.
+
+### The Policy:
+1. **No Silent Failures**: We must never let tests quietly pass if they cannot find an element that should be visible on normal screens.
+2. **Explicit Skipping**: Any test that explicitly interacts with, or asserts the visibility of, elements inside the hidden panels must be conditionally skipped on mobile viewports using Playwright's `isMobile` fixture:
+   ```ts
+   test('should have zoom controls', async ({ page, isMobile }) => {
+       test.skip(isMobile, 'Zoom controls are hidden on mobile viewports');
+       // ...
+   });
+   ```
+3. **Core Verification Enforced**: Drawing tools, canvas interactions (pointer down, drag, pointer up), grid limits, and tool-switching via the center toolbar or keyboard shortcuts are fully verified on mobile.

--- a/e2e/canvas.spec.ts
+++ b/e2e/canvas.spec.ts
@@ -76,7 +76,8 @@ test.describe('ASCII Canvas Editor', () => {
         expect(options).toContain('Dotted (*)');
     });
 
-    test('should have undo/redo buttons initially', async ({ page }) => {
+    test('should have undo/redo buttons initially', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Undo/redo buttons are hidden on mobile viewports');
         const undoBtn = page.locator('#undo-btn');
         const redoBtn = page.locator('#redo-btn');
         
@@ -84,7 +85,8 @@ test.describe('ASCII Canvas Editor', () => {
         await expect(redoBtn).toBeVisible();
     });
 
-    test('should have copy and clear buttons', async ({ page }) => {
+    test('should have copy and clear buttons', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Copy and clear buttons are hidden on mobile viewports');
         const copyBtn = page.locator('#copy-btn');
         await expect(copyBtn).toBeVisible();
         
@@ -92,14 +94,16 @@ test.describe('ASCII Canvas Editor', () => {
         await expect(clearBtn).toBeVisible();
     });
 
-    test('should have zoom controls', async ({ page }) => {
+    test('should have zoom controls', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Zoom controls are hidden on mobile viewports');
         await expect(page.locator('#zoom-fit')).toBeVisible();
         await expect(page.locator('#zoom-reset')).toBeVisible();
         await expect(page.locator('#zoom-out')).toBeVisible();
         await expect(page.locator('#zoom-in')).toBeVisible();
     });
 
-    test('should display cursor position', async ({ page }) => {
+    test('should display cursor position', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Side panel and status bar are hidden on mobile viewports');
         const cursorPos = page.locator('#cursor-pos');
         await expect(cursorPos).toBeVisible();
         
@@ -113,7 +117,8 @@ test.describe('ASCII Canvas Editor', () => {
         }
     });
 
-    test('should show status bar', async ({ page }) => {
+    test('should show status bar', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Status bar is hidden on mobile viewports');
         const statusBar = page.locator('.status-bar');
         await expect(statusBar).toBeVisible();
         
@@ -121,12 +126,14 @@ test.describe('ASCII Canvas Editor', () => {
         await expect(toolStatus).toContainText('Tool:');
     });
 
-    test('should show grid info', async ({ page }) => {
+    test('should show grid info', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Side panel is hidden on mobile viewports');
         const gridSize = page.locator('#grid-size');
         await expect(gridSize).toContainText(/(\d+) × (\d+)/);
     });
 
-    test('should show zoom level', async ({ page }) => {
+    test('should show zoom level', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Side panel is hidden on mobile viewports');
         const zoomLevel = page.locator('#zoom-level');
         await expect(zoomLevel).toContainText('100%');
     });
@@ -455,7 +462,8 @@ test.describe('Drawing Tools Interaction', () => {
 });
 
 test.describe('Undo/Redo', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Undo/redo buttons are hidden on mobile viewports');
         await openEditor(page);
     });
 
@@ -556,7 +564,8 @@ test.describe('Border Styles', () => {
         expect(selected).toBe('double');
     });
 
-    test('should cycle border styles with B key', async ({ page }) => {
+    test('should cycle border styles with B key', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Status bar and toast are hidden on mobile viewports');
         await page.click('#canvas');
         await waitForRender(page);
         
@@ -572,7 +581,8 @@ test.describe('Border Styles', () => {
 });
 
 test.describe('Zoom Controls', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Zoom controls and indicators are hidden on mobile viewports');
         await openEditor(page);
         await page.click('#zoom-reset');
         await waitForRender(page);
@@ -738,7 +748,8 @@ test.describe('Keyboard Shortcuts', () => {
 });
 
 test.describe('Copy Functionality', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Copy button and status toast are hidden on mobile viewports');
         await openEditor(page);
     });
 

--- a/e2e/clipboard.spec.ts
+++ b/e2e/clipboard.spec.ts
@@ -89,7 +89,8 @@ test.describe('Copy / export fidelity', () => {
         expect(forCopy).toBe(full);
     });
 
-    test('copy button shows toast', async ({ page }) => {
+    test('copy button shows toast', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Copy button and status toast are hidden on mobile viewports');
         await page.click('#copy-btn');
         const toast = page.locator('#status-toast');
         await expect(toast).not.toHaveClass(/hidden/);

--- a/web/main.ts
+++ b/web/main.ts
@@ -222,6 +222,12 @@ async function initialize() {
         // Hide loading overlay
         loadingOverlay.classList.add('hidden');
 
+        // Dispatch a resize event to ensure WebKit viewport/layout is fully synchronized
+        window.dispatchEvent(new Event('resize'));
+        setTimeout(() => {
+            window.dispatchEvent(new Event('resize'));
+        }, 100);
+
         // Focus canvas
         canvas.focus();
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -177,6 +177,17 @@ async function initialize() {
         // Set up canvas size first to have correct container rect
         resizeCanvas();
 
+        // If the container has collapsed height (e.g. layout pending on WebKit), wait for layout
+        let rect = canvasContainer.getBoundingClientRect();
+        if (rect.height < 50) {
+            for (let i = 0; i < 5; i++) {
+                await new Promise(resolve => requestAnimationFrame(resolve));
+                resizeCanvas();
+                rect = canvasContainer.getBoundingClientRect();
+                if (rect.height >= 50) break;
+            }
+        }
+
         // Create editor with responsive dimensions
         const { width, height } = computeGridDimensions();
         editor = new AsciiEditor(width, height) as unknown as AsciiEditorInterface;

--- a/web/style.css
+++ b/web/style.css
@@ -74,7 +74,7 @@ body {
 .app {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
     height: 100svh;
     overflow: hidden;
     padding-top: env(safe-area-inset-top);


### PR DESCRIPTION
This change addresses issue F-21 by introducing a parallel GitHub Actions CI matrix to execute Firefox and WebKit desktop projects alongside Chromium desktop tests. It resolves mobile viewport failures caused by responsive CSS rules (which hide the side panel, status bar, and certain toolbar containers on screens width <= 768px) by dynamically skipping elements interactions using Playwright's `isMobile` fixture. Finally, it documents the E2E architecture, flake budget, retry configuration, and mobile skip policy in `e2e/README.md`.

Fixes #117

---
*PR created automatically by Jules for task [6944307114976581696](https://jules.google.com/task/6944307114976581696) started by @d-o-hub*