### PR TITLE
SVG Export Feature Implementation (ADR-013)

### DIFF
--- a/e2e/canvas.spec.ts
+++ b/e2e/canvas.spec.ts
@@ -580,6 +580,25 @@ test.describe('Border Styles', () => {
     });
 });
 
+test.describe('Export Functionality', () => {
+    test.beforeEach(async ({ page, isMobile }) => {
+        test.skip(isMobile, 'Export buttons are hidden on mobile viewports');
+        await openEditor(page);
+    });
+
+    test('should have SVG and PNG export buttons', async ({ page }) => {
+        await expect(page.locator('#png-btn')).toBeVisible();
+        await expect(page.locator('#svg-btn')).toBeVisible();
+    });
+
+    test('should trigger SVG export on click', async ({ page }) => {
+        const downloadPromise = page.waitForEvent('download');
+        await page.click('#svg-btn');
+        const download = await downloadPromise;
+        expect(download.suggestedFilename()).toBe('ascii-canvas.svg');
+    });
+});
+
 test.describe('Zoom Controls', () => {
     test.beforeEach(async ({ page, isMobile }) => {
         test.skip(isMobile, 'Zoom controls and indicators are hidden on mobile viewports');

--- a/plans/ADRs/013-png-svg-export.md
+++ b/plans/ADRs/013-png-svg-export.md
@@ -1,7 +1,7 @@
 # ADR-013: PNG/SVG Export
 
 ## Status
-Accepted (PNG implemented 2026-07-15; SVG deferred)
+Accepted (PNG implemented 2026-07-15; SVG implemented 2026-07-16)
 
 ## Context
 Currently, users can only export ASCII text via clipboard. They cannot save diagrams as images for embedding in documents, presentations, or sharing.

--- a/src/wasm/helpers.rs
+++ b/src/wasm/helpers.rs
@@ -591,6 +591,21 @@ mod clipboard_tests {
     }
 
     #[test]
+    fn test_export_svg() {
+        let canvas = make_canvas_with_box();
+        let svg = canvas.export_svg();
+        assert!(svg.starts_with("<svg"));
+        assert!(svg.contains("<rect"));
+        assert!(svg.contains("<g fill="));
+        assert!(svg.contains("dominant-baseline=\"hanging\""));
+        assert!(svg.contains("┌"));
+        assert!(svg.contains("┐"));
+        assert!(svg.contains("┘"));
+        assert!(svg.contains("└"));
+        assert!(svg.ends_with("</g></svg>"));
+    }
+
+    #[test]
     fn test_copy_and_paste_at_selection_origin() {
         let mut canvas = make_canvas_with_box();
         canvas.set_selection_for_test(0, 0, 4, 2);

--- a/src/wasm/render_api.rs
+++ b/src/wasm/render_api.rs
@@ -17,6 +17,61 @@ impl AsciiEditor {
         export_ascii(&self.composite_visible_grid())
     }
 
+    /// Exports the composited visible canvas layers as an SVG vector image string.
+    #[wasm_bindgen(js_name = exportSvg)]
+    pub fn export_svg(&self) -> String {
+        let composite = self.composite_visible_grid();
+        let grid_width = composite.width();
+        let grid_height = composite.height();
+
+        let char_width = self.renderer.metrics().char_width;
+        let line_height = self.renderer.metrics().line_height;
+
+        let svg_width = grid_width as f64 * char_width;
+        let svg_height = grid_height as f64 * line_height;
+
+        let mut svg = String::new();
+        svg.push_str(&format!(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">"##,
+            w = svg_width,
+            h = svg_height
+        ));
+
+        // Background
+        svg.push_str(&format!(
+            r##"<rect width="{w}" height="{h}" fill="#1e1e1e" />"##,
+            w = svg_width,
+            h = svg_height
+        ));
+
+        // Group with shared styling
+        svg.push_str(&format!(
+            r##"<g fill="#d4d4d4" font-family="JetBrains Mono, Fira Code, Consolas, monospace" font-size="{size}px">"##,
+            size = self.renderer.metrics().size
+        ));
+
+        for y in 0..grid_height {
+            for x in 0..grid_width {
+                if let Some(cell) = composite.get(x as i32, y as i32) {
+                    if cell.is_visible() {
+                        let px = x as f64 * char_width;
+                        let py = y as f64 * line_height;
+                        let escaped = escape_xml_char(cell.ch);
+                        svg.push_str(&format!(
+                            r##"<text x="{x}" y="{y}" dominant-baseline="hanging">{char}</text>"##,
+                            x = px,
+                            y = py,
+                            char = escaped
+                        ));
+                    }
+                }
+            }
+        }
+
+        svg.push_str("</g></svg>");
+        svg
+    }
+
     /// Selection-aware export for the OS clipboard (selection region or trimmed full grid).
     #[wasm_bindgen(js_name = exportForCopy)]
     pub fn export_for_copy_public(&self) -> String {
@@ -264,5 +319,17 @@ impl AsciiEditor {
                 );
             }
         }
+    }
+}
+
+/// Escapes special XML/SVG characters in text elements.
+fn escape_xml_char(c: char) -> String {
+    match c {
+        '<' => "&lt;".to_string(),
+        '>' => "&gt;".to_string(),
+        '&' => "&amp;".to_string(),
+        '"' => "&quot;".to_string(),
+        '\'' => "&apos;".to_string(),
+        _ => c.to_string(),
     }
 }

--- a/web/exportSvg.ts
+++ b/web/exportSvg.ts
@@ -1,0 +1,36 @@
+/**
+ * SVG export helper.
+ */
+
+import { logger } from './logger.js';
+import type { ToastFn } from './clipboard.js';
+import type { AsciiEditorInterface } from './types.js';
+
+/**
+ * Export the current ASCII canvas as SVG and trigger download.
+ */
+export function exportSvg(
+    editor: AsciiEditorInterface,
+    showToast: ToastFn,
+    filename = 'ascii-canvas.svg',
+): void {
+    try {
+        const svgContent = editor.exportSvg();
+        const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+
+        // Clean up URL object after click
+        setTimeout(() => {
+            URL.revokeObjectURL(url);
+        }, 100);
+
+        showToast('Exported SVG');
+    } catch (err) {
+        logger.error('SVG export failed:', err);
+        showToast('Failed to export SVG', true);
+    }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -111,6 +111,10 @@
                     <span class="action-icon">🖼</span>
                     <span class="action-label">PNG</span>
                 </button>
+                <button id="svg-btn" class="action-btn" title="Export SVG" aria-label="Export as SVG">
+                    <span class="action-icon">📐</span>
+                    <span class="action-label">SVG</span>
+                </button>
                 <button id="clear-btn" class="action-btn" title="Clear Canvas" aria-label="Clear canvas">
                     <span class="action-icon">🗑</span>
                 </button>

--- a/web/main.ts
+++ b/web/main.ts
@@ -26,6 +26,7 @@ import {
     tryRestoreAutoSave,
 } from './persistence.js';
 import { exportPng } from './exportPng.js';
+import { exportSvg } from './exportSvg.js';
 
 // Global state
 let editor: AsciiEditorInterface | null = null;
@@ -492,6 +493,12 @@ function setupEventListeners() {
             requestAnimationFrame(() => {
                 exportPng(offscreenCanvas, canvas, showToast);
             });
+        }
+        if (canvas) canvas.focus();
+    });
+    wireOptionalButton('svg-btn', () => {
+        if (editor) {
+            exportSvg(editor, showToast);
         }
         if (canvas) canvas.focus();
     });

--- a/web/types.ts
+++ b/web/types.ts
@@ -47,6 +47,7 @@ export interface AsciiEditorInterface {
     selectAll(): void;
     exportAscii(): string;
     exportForCopy(): string;
+    exportSvg(): string;
     serializeDocument(): string;
     loadDocument(json: string): boolean;
     copySelection(): boolean;


### PR DESCRIPTION
Added loss-less SVG vector export feature to the ASCII Canvas editor, aligning with ADR-013 and F-10 follow-up. This implements a clean vector SVG generator of the composited visible canvas layers using absolute monospace positioning to preserve accurate visual alignment.

Fixes #110

---
*PR created automatically by Jules for task [1355731333808496182](https://jules.google.com/task/1355731333808496182) started by @d-o-hub*