### PR TITLE
feat(layers): Full layer editor — lock, reorder, delete, merge, history

### DIFF
--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -5,7 +5,7 @@ use crate::core::grid::Grid;
 use std::collections::VecDeque;
 
 /// Maximum history depth.
-const DEFAULT_MAX_DEPTH: usize = 100;
+pub const DEFAULT_MAX_DEPTH: usize = 100;
 
 /// Undo/Redo history manager.
 pub struct History {

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -17,6 +17,16 @@ pub struct History {
     max_depth: usize,
 }
 
+impl std::fmt::Debug for History {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("History")
+            .field("max_depth", &self.max_depth)
+            .field("undo_count", &self.undo_stack.len())
+            .field("redo_count", &self.redo_stack.len())
+            .finish()
+    }
+}
+
 impl Default for History {
     fn default() -> Self {
         Self::new(DEFAULT_MAX_DEPTH)

--- a/src/wasm/bindings.rs
+++ b/src/wasm/bindings.rs
@@ -44,11 +44,25 @@ pub struct AsciiEditor {
 }
 
 /// Serializable layer metadata + content snapshot.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct LayerData {
     pub name: String,
     pub visible: bool,
+    pub locked: bool,
     pub grid: crate::core::Grid,
+    pub history: History,
+}
+
+impl Clone for LayerData {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            visible: self.visible,
+            locked: self.locked,
+            grid: self.grid.clone(),
+            history: History::new(100),
+        }
+    }
 }
 
 #[wasm_bindgen]
@@ -83,7 +97,9 @@ impl AsciiEditor {
             layers: vec![LayerData {
                 name: "Layer 1".to_string(),
                 visible: true,
+                locked: false,
                 grid: crate::core::Grid::new(width, height),
+                history: History::new(100),
             }],
             active_layer: 0,
         }
@@ -204,6 +220,9 @@ impl AsciiEditor {
     /// Reverts the last drawing operation. Returns true if successful.
     #[wasm_bindgen]
     pub fn undo(&mut self) -> bool {
+        if self.is_active_layer_locked() {
+            return false;
+        }
         let result = self.history.undo(&mut self.state.grid);
         if result {
             self.dirty_tracker.request_full_redraw();
@@ -214,6 +233,9 @@ impl AsciiEditor {
     /// Re-applies a previously undone operation. Returns true if successful.
     #[wasm_bindgen]
     pub fn redo(&mut self) -> bool {
+        if self.is_active_layer_locked() {
+            return false;
+        }
         let result = self.history.redo(&mut self.state.grid);
         if result {
             self.dirty_tracker.request_full_redraw();
@@ -236,6 +258,9 @@ impl AsciiEditor {
     /// Clears the canvas, history, clipboard, and reset layers.
     #[wasm_bindgen]
     pub fn clear(&mut self) {
+        if self.is_active_layer_locked() {
+            return;
+        }
         self.state.grid.clear();
         if let Some(layer) = self.layers.get_mut(self.active_layer) {
             layer.grid.clear();

--- a/src/wasm/bindings.rs
+++ b/src/wasm/bindings.rs
@@ -1,6 +1,6 @@
 //! WASM bindings - struct definition, constructor, and core methods.
 
-use crate::core::history::History;
+use crate::core::history::{History, DEFAULT_MAX_DEPTH};
 use crate::core::selection::{Selection, SelectionClipboard};
 use crate::core::tools::{DrawOp, RectangleTool, Tool, ToolId};
 use crate::core::EditorState;
@@ -54,13 +54,14 @@ pub(crate) struct LayerData {
 }
 
 impl Clone for LayerData {
+    // NOTE: history is intentionally reset on clone to avoid sharing undo history state.
     fn clone(&self) -> Self {
         Self {
             name: self.name.clone(),
             visible: self.visible,
             locked: self.locked,
             grid: self.grid.clone(),
-            history: History::new(100),
+            history: History::new(DEFAULT_MAX_DEPTH),
         }
     }
 }
@@ -75,7 +76,7 @@ impl AsciiEditor {
 
         Self {
             state,
-            history: History::new(100),
+            history: History::new(DEFAULT_MAX_DEPTH),
             renderer,
             dirty_tracker: DirtyTracker::new(),
             active_tool: Box::new(RectangleTool::new()),
@@ -99,7 +100,7 @@ impl AsciiEditor {
                 visible: true,
                 locked: false,
                 grid: crate::core::Grid::new(width, height),
-                history: History::new(100),
+                history: History::new(DEFAULT_MAX_DEPTH),
             }],
             active_layer: 0,
         }

--- a/src/wasm/event_handlers.rs
+++ b/src/wasm/event_handlers.rs
@@ -15,6 +15,9 @@ impl AsciiEditor {
             self.last_pan_pos = Some((screen_x, screen_y));
             return JsValue::NULL;
         }
+        if self.is_active_layer_locked() {
+            return self.js_event_result();
+        }
 
         let (x, y) = self.renderer.screen_to_grid(screen_x, screen_y);
         self.last_cursor = Some((x, y));
@@ -63,6 +66,9 @@ impl AsciiEditor {
             self.last_pan_pos = Some((screen_x, screen_y));
             return self.js_event_result();
         }
+        if self.is_active_layer_locked() {
+            return self.js_event_result();
+        }
 
         let (x, y) = self.renderer.screen_to_grid(screen_x, screen_y);
         self.last_cursor = Some((x, y));
@@ -96,6 +102,9 @@ impl AsciiEditor {
         if self.is_panning {
             self.is_panning = false;
             self.last_pan_pos = None;
+            return self.js_event_result();
+        }
+        if self.is_active_layer_locked() {
             return self.js_event_result();
         }
 
@@ -184,6 +193,9 @@ impl AsciiEditor {
         }
 
         if !ctrl && (key == "Delete" || key == "Backspace") {
+            if self.is_active_layer_locked() {
+                return self.js_event_result();
+            }
             if self.tool_id == ToolId::Select
                 && self.current_selection.is_some()
                 && self.delete_selection_impl()
@@ -209,6 +221,9 @@ impl AsciiEditor {
         }
 
         if self.tool_id == ToolId::Text && self.active_tool.is_active() {
+            if self.is_active_layer_locked() {
+                return self.js_event_result();
+            }
             let ctx = self.create_tool_context();
             let result = self.active_tool.on_key(key_char, &ctx);
             if result.modified {

--- a/src/wasm/helpers.rs
+++ b/src/wasm/helpers.rs
@@ -385,7 +385,10 @@ impl AsciiEditor {
 
         // Swap active history into old active layer's history
         let mut temp_history = std::mem::take(&mut self.history);
-        std::mem::swap(&mut temp_history, &mut self.layers[self.active_layer].history);
+        std::mem::swap(
+            &mut temp_history,
+            &mut self.layers[self.active_layer].history,
+        );
 
         self.layers.push(super::bindings::LayerData {
             name,
@@ -405,23 +408,35 @@ impl AsciiEditor {
     }
 
     pub(crate) fn move_layer_impl(&mut self, from_index: usize, to_index: usize) {
-        if from_index >= self.layers.len() || to_index >= self.layers.len() || from_index == to_index {
+        if from_index >= self.layers.len()
+            || to_index >= self.layers.len()
+            || from_index == to_index
+        {
             return;
         }
         self.sync_active_layer();
 
         // Temporarily swap active history back to active layer for moving
         let mut temp_history = std::mem::take(&mut self.history);
-        std::mem::swap(&mut temp_history, &mut self.layers[self.active_layer].history);
+        std::mem::swap(
+            &mut temp_history,
+            &mut self.layers[self.active_layer].history,
+        );
 
         let layer = self.layers.remove(from_index);
         self.layers.insert(to_index, layer);
 
         if self.active_layer == from_index {
             self.active_layer = to_index;
-        } else if from_index < to_index && self.active_layer > from_index && self.active_layer <= to_index {
+        } else if from_index < to_index
+            && self.active_layer > from_index
+            && self.active_layer <= to_index
+        {
             self.active_layer -= 1;
-        } else if from_index > to_index && self.active_layer >= to_index && self.active_layer < from_index {
+        } else if from_index > to_index
+            && self.active_layer >= to_index
+            && self.active_layer < from_index
+        {
             self.active_layer += 1;
         }
 

--- a/src/wasm/helpers.rs
+++ b/src/wasm/helpers.rs
@@ -2,6 +2,7 @@
 
 use crate::core::ascii_export::export_region;
 use crate::core::commands::{Command, DrawCommand};
+use crate::core::history::History;
 use crate::core::selection::{Selection, SelectionClipboard};
 use crate::core::tools::{DrawOp, SelectTool, ToolContext, ToolId};
 use crate::wasm::render_bridge::{
@@ -44,6 +45,9 @@ impl AsciiEditor {
     }
 
     pub(crate) fn commit_ops(&mut self, ops: &[DrawOp]) {
+        if self.is_active_layer_locked() {
+            return;
+        }
         if ops.is_empty() {
             return;
         }
@@ -247,6 +251,9 @@ impl AsciiEditor {
     }
 
     pub(crate) fn cut_selection_impl(&mut self) -> bool {
+        if self.is_active_layer_locked() {
+            return false;
+        }
         if self.current_selection.is_none() {
             return false;
         }
@@ -278,6 +285,9 @@ impl AsciiEditor {
     }
 
     pub(crate) fn paste_impl(&mut self) -> bool {
+        if self.is_active_layer_locked() {
+            return false;
+        }
         if self.clipboard.is_empty() {
             return false;
         }
@@ -307,6 +317,9 @@ impl AsciiEditor {
     }
 
     pub(crate) fn delete_selection_impl(&mut self) -> bool {
+        if self.is_active_layer_locked() {
+            return false;
+        }
         if self.tool_id != ToolId::Select {
             return false;
         }
@@ -346,13 +359,20 @@ impl AsciiEditor {
             return index < self.layers.len();
         }
         self.sync_active_layer();
+
+        let old_active = self.active_layer;
         self.active_layer = index;
+
+        // Swap history!
+        let mut temp_history = std::mem::take(&mut self.history);
+        std::mem::swap(&mut temp_history, &mut self.layers[old_active].history);
+        self.history = std::mem::take(&mut self.layers[index].history);
+
         if let Some(layer) = self.layers.get(index) {
             self.state.grid = layer.grid.clone();
         }
         self.current_selection = None;
         self.preview_ops.clear();
-        self.history.clear();
         self.dirty_tracker.request_full_redraw();
         true
     }
@@ -362,19 +382,113 @@ impl AsciiEditor {
         let w = self.state.grid.width();
         let h = self.state.grid.height();
         let name = format!("Layer {}", self.layers.len() + 1);
+
+        // Swap active history into old active layer's history
+        let mut temp_history = std::mem::take(&mut self.history);
+        std::mem::swap(&mut temp_history, &mut self.layers[self.active_layer].history);
+
         self.layers.push(super::bindings::LayerData {
             name,
             visible: true,
+            locked: false,
             grid: crate::core::Grid::new(w, h),
+            history: History::new(100),
         });
         let index = self.layers.len() - 1;
         self.active_layer = index;
         self.state.grid = crate::core::Grid::new(w, h);
+        self.history = History::new(100); // fresh history for the new layer
         self.current_selection = None;
         self.preview_ops.clear();
-        self.history.clear();
         self.dirty_tracker.request_full_redraw();
         index
+    }
+
+    pub(crate) fn move_layer_impl(&mut self, from_index: usize, to_index: usize) {
+        if from_index >= self.layers.len() || to_index >= self.layers.len() || from_index == to_index {
+            return;
+        }
+        self.sync_active_layer();
+
+        // Temporarily swap active history back to active layer for moving
+        let mut temp_history = std::mem::take(&mut self.history);
+        std::mem::swap(&mut temp_history, &mut self.layers[self.active_layer].history);
+
+        let layer = self.layers.remove(from_index);
+        self.layers.insert(to_index, layer);
+
+        if self.active_layer == from_index {
+            self.active_layer = to_index;
+        } else if from_index < to_index && self.active_layer > from_index && self.active_layer <= to_index {
+            self.active_layer -= 1;
+        } else if from_index > to_index && self.active_layer >= to_index && self.active_layer < from_index {
+            self.active_layer += 1;
+        }
+
+        // Swap history back from the new active layer
+        let mut temp_history = std::mem::take(&mut self.layers[self.active_layer].history);
+        std::mem::swap(&mut temp_history, &mut self.history);
+
+        self.state.grid = self.layers[self.active_layer].grid.clone();
+        self.dirty_tracker.request_full_redraw();
+    }
+
+    pub(crate) fn delete_layer_impl(&mut self, index: usize) -> bool {
+        if self.layers.len() <= 1 || index >= self.layers.len() {
+            return false;
+        }
+        self.sync_active_layer();
+
+        self.layers.remove(index);
+
+        if self.active_layer >= self.layers.len() {
+            self.active_layer = self.layers.len() - 1;
+        }
+
+        // Restore active grid and history
+        self.state.grid = self.layers[self.active_layer].grid.clone();
+        self.history = std::mem::take(&mut self.layers[self.active_layer].history);
+
+        self.current_selection = None;
+        self.preview_ops.clear();
+        self.dirty_tracker.request_full_redraw();
+        true
+    }
+
+    pub(crate) fn merge_down_impl(&mut self, index: usize) -> bool {
+        if index == 0 || index >= self.layers.len() {
+            return false;
+        }
+        self.sync_active_layer();
+
+        // Clone upper layer's grid
+        let upper_grid = self.layers[index].grid.clone();
+
+        // Merge into lower layer
+        {
+            let lower_layer = &mut self.layers[index - 1];
+            for (x, y, cell) in upper_grid.iter_with_coords() {
+                if cell.is_visible() {
+                    lower_layer.grid.set(x, y, *cell);
+                }
+            }
+        }
+
+        self.layers.remove(index);
+
+        if self.active_layer == index {
+            self.active_layer = index - 1;
+        } else if self.active_layer > index {
+            self.active_layer -= 1;
+        }
+
+        self.state.grid = self.layers[self.active_layer].grid.clone();
+        self.history = std::mem::take(&mut self.layers[self.active_layer].history);
+
+        self.current_selection = None;
+        self.preview_ops.clear();
+        self.dirty_tracker.request_full_redraw();
+        true
     }
 
     /// Composite all visible layers (bottom → top) into a single grid.
@@ -413,6 +527,7 @@ impl AsciiEditor {
         struct DocLayer {
             name: String,
             visible: bool,
+            locked: bool,
             cells: Vec<DocCell>,
         }
         #[derive(serde::Serialize)]
@@ -449,6 +564,7 @@ impl AsciiEditor {
             layers.push(DocLayer {
                 name: layer.name.clone(),
                 visible: layer.visible,
+                locked: layer.locked,
                 cells,
             });
         }
@@ -484,10 +600,15 @@ impl AsciiEditor {
             name: String,
             #[serde(default = "default_true")]
             visible: bool,
+            #[serde(default = "default_false")]
+            locked: bool,
             cells: Vec<DocCell>,
         }
         fn default_true() -> bool {
             true
+        }
+        fn default_false() -> bool {
+            false
         }
         #[derive(serde::Deserialize)]
         struct CanvasSize {
@@ -537,7 +658,9 @@ impl AsciiEditor {
             layers.push(super::bindings::LayerData {
                 name: layer.name,
                 visible: layer.visible,
+                locked: layer.locked,
                 grid,
+                history: History::new(100),
             });
         }
 
@@ -719,5 +842,107 @@ mod clipboard_tests {
             ascii.contains('A') && ascii.contains('B'),
             "selection export must composite layers: {ascii:?}"
         );
+    }
+
+    #[test]
+    fn test_layer_lock_prevents_draw_ops() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        // Lock the layer
+        canvas.set_layer_locked(0, true);
+        assert!(canvas.layer_locked(0));
+
+        // Try to write a character (e.g. via commit_ops)
+        use crate::core::tools::DrawOp;
+        canvas.commit_ops(&[DrawOp::new(1, 1, 'X')]);
+        // Cell should remain empty
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, ' ');
+
+        // Try to clear
+        canvas.clear();
+        assert!(!canvas.state.grid.get(1, 1).unwrap().is_visible());
+    }
+
+    #[test]
+    fn test_reorder_layers_preserves_indices() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        canvas.state.grid.set_char(0, 0, 'A');
+
+        let _idx1 = canvas.add_layer_impl();
+        canvas.state.grid.set_char(1, 1, 'B');
+
+        let _idx2 = canvas.add_layer_impl();
+        canvas.state.grid.set_char(2, 2, 'C');
+
+        assert_eq!(canvas.layers.len(), 3);
+        assert_eq!(canvas.active_layer, 2);
+
+        // Move active layer (2) down to index 1
+        canvas.move_layer(2, 1);
+        assert_eq!(canvas.active_layer, 1);
+        assert_eq!(canvas.layers[1].name, "Layer 3"); // C should now be at index 1
+        assert_eq!(canvas.layers[2].name, "Layer 2"); // B should now be at index 2
+    }
+
+    #[test]
+    fn test_delete_layer_prevents_deleting_last_layer() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        assert_eq!(canvas.layers.len(), 1);
+
+        // Try deleting layer 0 (the only layer)
+        assert!(!canvas.delete_layer(0));
+        assert_eq!(canvas.layers.len(), 1);
+
+        // Add a layer and delete it
+        canvas.add_layer_impl();
+        assert_eq!(canvas.layers.len(), 2);
+        assert!(canvas.delete_layer(1));
+        assert_eq!(canvas.layers.len(), 1);
+        assert_eq!(canvas.active_layer, 0);
+    }
+
+    #[test]
+    fn test_merge_layer_down_composites_cells() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        canvas.state.grid.set_char(0, 0, 'A');
+
+        canvas.add_layer_impl();
+        canvas.state.grid.set_char(1, 1, 'B');
+
+        // Merge layer 1 down to layer 0
+        assert!(canvas.merge_layer_down(1));
+        assert_eq!(canvas.layers.len(), 1);
+        assert_eq!(canvas.active_layer, 0);
+
+        // Cell 'A' from bottom and 'B' from top should now both be in the bottom grid
+        assert_eq!(canvas.state.grid.get(0, 0).unwrap().ch, 'A');
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'B');
+    }
+
+    #[test]
+    fn test_layer_history_preservation_across_switches() {
+        let mut canvas = AsciiEditor::new(10, 10);
+
+        // Draw 'A' on Layer 0 (creates an undo step on Layer 0)
+        use crate::core::tools::DrawOp;
+        canvas.commit_ops(&[DrawOp::new(0, 0, 'A')]);
+        assert_eq!(canvas.state.grid.get(0, 0).unwrap().ch, 'A');
+        assert!(canvas.can_undo());
+
+        // Add Layer 1 and draw 'B'
+        canvas.add_layer_impl();
+        canvas.commit_ops(&[DrawOp::new(1, 1, 'B')]);
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'B');
+        assert!(canvas.can_undo());
+
+        // Switch to Layer 0
+        canvas.set_active_layer(0);
+        assert_eq!(canvas.state.grid.get(0, 0).unwrap().ch, 'A');
+        // Undo on Layer 0 should undo 'A' but keep 'B' on Layer 1 intact
+        assert!(canvas.undo());
+        assert_eq!(canvas.state.grid.get(0, 0).unwrap().ch, ' ');
+
+        // Switch back to Layer 1 and verify 'B' is still there
+        canvas.set_active_layer(1);
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'B');
     }
 }

--- a/src/wasm/helpers.rs
+++ b/src/wasm/helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::core::ascii_export::export_region;
 use crate::core::commands::{Command, DrawCommand};
-use crate::core::history::History;
+use crate::core::history::{History, DEFAULT_MAX_DEPTH};
 use crate::core::selection::{Selection, SelectionClipboard};
 use crate::core::tools::{DrawOp, SelectTool, ToolContext, ToolId};
 use crate::wasm::render_bridge::{
@@ -395,12 +395,12 @@ impl AsciiEditor {
             visible: true,
             locked: false,
             grid: crate::core::Grid::new(w, h),
-            history: History::new(100),
+            history: History::new(DEFAULT_MAX_DEPTH),
         });
         let index = self.layers.len() - 1;
         self.active_layer = index;
         self.state.grid = crate::core::Grid::new(w, h);
-        self.history = History::new(100); // fresh history for the new layer
+        self.history = History::new(DEFAULT_MAX_DEPTH); // fresh history for the new layer
         self.current_selection = None;
         self.preview_ops.clear();
         self.dirty_tracker.request_full_redraw();
@@ -454,10 +454,21 @@ impl AsciiEditor {
         }
         self.sync_active_layer();
 
+        // Temporarily swap active history back to active layer before structural changes
+        let mut temp_history = std::mem::take(&mut self.history);
+        std::mem::swap(
+            &mut temp_history,
+            &mut self.layers[self.active_layer].history,
+        );
+
         self.layers.remove(index);
 
-        if self.active_layer >= self.layers.len() {
-            self.active_layer = self.layers.len() - 1;
+        if self.active_layer == index {
+            if self.active_layer >= self.layers.len() {
+                self.active_layer = self.layers.len() - 1;
+            }
+        } else if self.active_layer > index {
+            self.active_layer -= 1;
         }
 
         // Restore active grid and history
@@ -475,6 +486,13 @@ impl AsciiEditor {
             return false;
         }
         self.sync_active_layer();
+
+        // Temporarily swap active history back to active layer before structural changes
+        let mut temp_history = std::mem::take(&mut self.history);
+        std::mem::swap(
+            &mut temp_history,
+            &mut self.layers[self.active_layer].history,
+        );
 
         // Clone upper layer's grid
         let upper_grid = self.layers[index].grid.clone();
@@ -675,7 +693,7 @@ impl AsciiEditor {
                 visible: layer.visible,
                 locked: layer.locked,
                 grid,
-                history: History::new(100),
+                history: History::new(DEFAULT_MAX_DEPTH),
             });
         }
 
@@ -862,18 +880,32 @@ mod clipboard_tests {
     #[test]
     fn test_layer_lock_prevents_draw_ops() {
         let mut canvas = AsciiEditor::new(10, 10);
+        // Pre-populate a cell
+        use crate::core::tools::DrawOp;
+        canvas.commit_ops(&[DrawOp::new(1, 1, 'A')]);
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'A');
+
         // Lock the layer
         canvas.set_layer_locked(0, true);
         assert!(canvas.layer_locked(0));
 
-        // Try to write a character (e.g. via commit_ops)
-        use crate::core::tools::DrawOp;
-        canvas.commit_ops(&[DrawOp::new(1, 1, 'X')]);
-        // Cell should remain empty
-        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, ' ');
+        // Try to write a character (e.g. via commit_ops) while locked
+        canvas.commit_ops(&[DrawOp::new(2, 2, 'X')]);
+        // Cell (2, 2) should remain empty
+        assert_eq!(canvas.state.grid.get(2, 2).unwrap().ch, ' ');
 
-        // Try to clear
+        // Try to clear while locked
         canvas.clear();
+        // Cell (1, 1) should STILL be 'A' because clear was blocked by lock
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'A');
+
+        // Unlock the layer
+        canvas.set_layer_locked(0, false);
+        assert!(!canvas.layer_locked(0));
+
+        // Try clearing now that it is unlocked
+        canvas.clear();
+        // Cell should now be cleared
         assert!(!canvas.state.grid.get(1, 1).unwrap().is_visible());
     }
 

--- a/src/wasm/render_api.rs
+++ b/src/wasm/render_api.rs
@@ -146,6 +146,44 @@ impl AsciiEditor {
         }
     }
 
+    /// Whether a layer is locked.
+    #[wasm_bindgen(js_name = layerLocked)]
+    pub fn layer_locked(&self, index: usize) -> bool {
+        self.layers.get(index).map(|l| l.locked).unwrap_or(false)
+    }
+
+    /// Set layer lock state.
+    #[wasm_bindgen(js_name = setLayerLocked)]
+    pub fn set_layer_locked(&mut self, index: usize, locked: bool) {
+        if let Some(layer) = self.layers.get_mut(index) {
+            layer.locked = locked;
+            self.dirty_tracker.request_full_redraw();
+        }
+    }
+
+    /// Move a layer to a new index in the stack.
+    #[wasm_bindgen(js_name = moveLayer)]
+    pub fn move_layer(&mut self, from_index: usize, to_index: usize) {
+        self.move_layer_impl(from_index, to_index);
+    }
+
+    /// Delete a layer.
+    #[wasm_bindgen(js_name = deleteLayer)]
+    pub fn delete_layer(&mut self, index: usize) -> bool {
+        self.delete_layer_impl(index)
+    }
+
+    /// Merge the specified layer down into the one below it.
+    #[wasm_bindgen(js_name = mergeLayerDown)]
+    pub fn merge_layer_down(&mut self, index: usize) -> bool {
+        self.merge_down_impl(index)
+    }
+
+    /// Returns whether the active layer is locked.
+    pub(crate) fn is_active_layer_locked(&self) -> bool {
+        self.layers.get(self.active_layer).map(|l| l.locked).unwrap_or(false)
+    }
+
     /// Returns the full list of drawing instructions/commands to render the entire canvas in JS.
     #[wasm_bindgen(js_name = getRenderCommands)]
     pub fn get_render_commands(&mut self) -> JsValue {

--- a/src/wasm/render_api.rs
+++ b/src/wasm/render_api.rs
@@ -181,7 +181,10 @@ impl AsciiEditor {
 
     /// Returns whether the active layer is locked.
     pub(crate) fn is_active_layer_locked(&self) -> bool {
-        self.layers.get(self.active_layer).map(|l| l.locked).unwrap_or(false)
+        self.layers
+            .get(self.active_layer)
+            .map(|l| l.locked)
+            .unwrap_or(false)
     }
 
     /// Returns the full list of drawing instructions/commands to render the entire canvas in JS.

--- a/web/index.html
+++ b/web/index.html
@@ -188,8 +188,8 @@
                     <h3 class="section-title" id="layers-title">Layers</h3>
                     <div class="layer-list-container">
                         <div id="layer-list" class="layer-list" role="list" aria-label="Layers list"></div>
-                        <div class="layer-actions" style="margin-top: var(--spacing-sm); display: flex; gap: var(--spacing-xs);">
-                            <button id="add-layer-btn" class="zoom-btn" type="button" title="Add layer" aria-label="Add layer" style="flex: 1;">+ Add Layer</button>
+                        <div class="layer-actions">
+                            <button id="add-layer-btn" class="zoom-btn" type="button" title="Add layer" aria-label="Add layer">+ Add Layer</button>
                         </div>
                     </div>
                 </section>

--- a/web/index.html
+++ b/web/index.html
@@ -186,10 +186,11 @@
                 <!-- Layers -->
                 <section class="panel-section" aria-labelledby="layers-title">
                     <h3 class="section-title" id="layers-title">Layers</h3>
-                    <div class="layer-controls">
-                        <label class="visually-hidden" for="layer-select">Active layer</label>
-                        <select id="layer-select" class="select-input" aria-label="Active layer"></select>
-                        <button id="add-layer-btn" class="zoom-btn" type="button" title="Add layer" aria-label="Add layer">+</button>
+                    <div class="layer-list-container">
+                        <div id="layer-list" class="layer-list" role="list" aria-label="Layers list"></div>
+                        <div class="layer-actions" style="margin-top: var(--spacing-sm); display: flex; gap: var(--spacing-xs);">
+                            <button id="add-layer-btn" class="zoom-btn" type="button" title="Add layer" aria-label="Add layer" style="flex: 1;">+ Add Layer</button>
+                        </div>
                     </div>
                 </section>
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -1187,11 +1187,18 @@ function refreshLayerList() {
     let hasChanged = count !== lastLayerCount || active !== lastActiveLayer || currentStates.length !== lastLayersState.length;
     if (!hasChanged) {
         for (let i = 0; i < count; i++) {
-            if (
-                currentStates[i].name !== lastLayersState[i].name ||
-                currentStates[i].visible !== lastLayersState[i].visible ||
-                currentStates[i].locked !== lastLayersState[i].locked
-            ) {
+            const cur = currentStates.at(i);
+            const last = lastLayersState.at(i);
+            if (cur && last) {
+                if (
+                    cur.name !== last.name ||
+                    cur.visible !== last.visible ||
+                    cur.locked !== last.locked
+                ) {
+                    hasChanged = true;
+                    break;
+                }
+            } else {
                 hasChanged = true;
                 break;
             }

--- a/web/main.ts
+++ b/web/main.ts
@@ -1159,8 +1159,54 @@ function syncGridInputs() {
     gridHeightInput.value = String(editor.height);
 }
 
+interface CachedLayerState {
+    name: string;
+    visible: boolean;
+    locked: boolean;
+}
+let lastLayerCount = 0;
+let lastActiveLayer = -1;
+let lastLayersState: CachedLayerState[] = [];
+
 function refreshLayerList() {
     if (!editor || typeof editor.layerCount !== 'number') return;
+    const count = editor.layerCount;
+    const active = editor.activeLayer ?? 0;
+
+    // Build current state to diff and prevent unnecessary DOM churn/input focus loss
+    const currentStates: CachedLayerState[] = [];
+    for (let i = 0; i < count; i++) {
+        currentStates.push({
+            name: editor.layerName(i),
+            visible: editor.layerVisible(i),
+            locked: editor.layerLocked(i),
+        });
+    }
+
+    // Diff states
+    let hasChanged = count !== lastLayerCount || active !== lastActiveLayer || currentStates.length !== lastLayersState.length;
+    if (!hasChanged) {
+        for (let i = 0; i < count; i++) {
+            if (
+                currentStates[i].name !== lastLayersState[i].name ||
+                currentStates[i].visible !== lastLayersState[i].visible ||
+                currentStates[i].locked !== lastLayersState[i].locked
+            ) {
+                hasChanged = true;
+                break;
+            }
+        }
+    }
+
+    if (!hasChanged) {
+        return;
+    }
+
+    // Update cache
+    lastLayerCount = count;
+    lastActiveLayer = active;
+    lastLayersState = currentStates;
+
     const layerList = document.querySelector('#layer-list');
     if (!(layerList instanceof HTMLElement)) return;
 
@@ -1168,9 +1214,6 @@ function refreshLayerList() {
     while (layerList.firstChild) {
         layerList.removeChild(layerList.firstChild);
     }
-
-    const count = editor.layerCount;
-    const active = editor.activeLayer ?? 0;
 
     // Iterate through layers, displaying top layers first (index count - 1 to 0)
     for (let i = count - 1; i >= 0; i--) {
@@ -1241,6 +1284,8 @@ function refreshLayerList() {
         });
 
         // Reorder Up Button
+        // Since the list renders descending (top layer first), "up" means moving the layer visually
+        // toward higher indices in the z-order stack, so we disable it if it is already the topmost layer.
         const upBtn = document.createElement('button');
         upBtn.className = 'layer-item-btn';
         upBtn.type = 'button';
@@ -1258,6 +1303,8 @@ function refreshLayerList() {
         });
 
         // Reorder Down Button
+        // "Down" visually moves the layer toward lower indices in the z-order stack, so we disable it
+        // if it is already the bottom-most layer (index 0).
         const downBtn = document.createElement('button');
         downBtn.className = 'layer-item-btn';
         downBtn.type = 'button';

--- a/web/main.ts
+++ b/web/main.ts
@@ -1197,7 +1197,7 @@ function refreshLayerList() {
         visBtn.className = 'layer-item-btn';
         if (visible) visBtn.classList.add('active');
         visBtn.type = 'button';
-        visBtn.innerHTML = visible ? '👁' : '◌';
+        visBtn.textContent = visible ? '👁' : '◌';
         visBtn.title = visible ? 'Hide layer' : 'Show layer';
         visBtn.setAttribute('aria-label', visible ? 'Hide layer' : 'Show layer');
         visBtn.addEventListener('click', () => {
@@ -1215,7 +1215,7 @@ function refreshLayerList() {
         lockBtn.className = 'layer-item-btn';
         if (locked) lockBtn.classList.add('active');
         lockBtn.type = 'button';
-        lockBtn.innerHTML = locked ? '🔒' : '🔓';
+        lockBtn.textContent = locked ? '🔒' : '🔓';
         lockBtn.title = locked ? 'Unlock layer' : 'Lock layer';
         lockBtn.setAttribute('aria-label', locked ? 'Unlock layer' : 'Lock layer');
         lockBtn.addEventListener('click', () => {
@@ -1244,7 +1244,7 @@ function refreshLayerList() {
         const upBtn = document.createElement('button');
         upBtn.className = 'layer-item-btn';
         upBtn.type = 'button';
-        upBtn.innerHTML = '↑';
+        upBtn.textContent = '↑';
         upBtn.title = 'Move up';
         upBtn.setAttribute('aria-label', 'Move up');
         upBtn.disabled = i === count - 1;
@@ -1261,7 +1261,7 @@ function refreshLayerList() {
         const downBtn = document.createElement('button');
         downBtn.className = 'layer-item-btn';
         downBtn.type = 'button';
-        downBtn.innerHTML = '↓';
+        downBtn.textContent = '↓';
         downBtn.title = 'Move down';
         downBtn.setAttribute('aria-label', 'Move down');
         downBtn.disabled = i === 0;
@@ -1278,7 +1278,7 @@ function refreshLayerList() {
         const mergeBtn = document.createElement('button');
         mergeBtn.className = 'layer-item-btn';
         mergeBtn.type = 'button';
-        mergeBtn.innerHTML = '↴';
+        mergeBtn.textContent = '↴';
         mergeBtn.title = 'Merge down';
         mergeBtn.setAttribute('aria-label', 'Merge down');
         mergeBtn.disabled = i === 0;
@@ -1296,7 +1296,7 @@ function refreshLayerList() {
         const delBtn = document.createElement('button');
         delBtn.className = 'layer-item-btn';
         delBtn.type = 'button';
-        delBtn.innerHTML = '🗑';
+        delBtn.textContent = '🗑';
         delBtn.title = 'Delete layer';
         delBtn.setAttribute('aria-label', 'Delete layer');
         delBtn.disabled = count <= 1;

--- a/web/main.ts
+++ b/web/main.ts
@@ -212,7 +212,6 @@ async function initialize() {
 
         // Update UI
         updateUI();
-        refreshLayerSelect();
         syncGridInputs();
 
         // Initial render
@@ -479,7 +478,6 @@ function setupEventListeners() {
             gridSizeLocked = true;
             offscreenCanvas = null;
             offscreenCtx = null;
-            refreshLayerSelect();
             syncGridInputs();
             requestRender();
             updateUI();
@@ -509,28 +507,12 @@ function setupEventListeners() {
     wireOptionalButton('add-layer-btn', () => {
         if (!editor) return;
         editor.addLayer();
-        refreshLayerSelect();
         requestRender();
         updateUI();
         scheduleAutoSave();
         showToast('Layer added');
         if (canvas) canvas.focus();
     });
-
-    const layerSelectEl = document.querySelector('#layer-select');
-    if (layerSelectEl instanceof HTMLSelectElement) {
-        layerSelectEl.addEventListener('change', () => {
-            if (!editor) return;
-            const idx = parseInt(layerSelectEl.value, 10);
-            if (!Number.isNaN(idx)) {
-                editor.setActiveLayer(idx);
-                requestRender();
-                updateUI();
-                scheduleAutoSave();
-            }
-            if (canvas) canvas.focus();
-        });
-    }
 
     helpBtn.addEventListener('mousedown', (e) => e.preventDefault());
     helpBtn.addEventListener('click', showShortcutsModal);
@@ -1123,6 +1105,7 @@ function updateUI() {
         redoBtn.disabled = !editor.can_redo;
         gridSizeEl.textContent = `${editor.width} × ${editor.height}`;
         statusToolEl.textContent = `Tool: ${capitalize(editor.tool)}`;
+        refreshLayerList();
     } catch (error) {
         logger.error('Failed to update UI:', error);
     }
@@ -1176,21 +1159,169 @@ function syncGridInputs() {
     gridHeightInput.value = String(editor.height);
 }
 
-function refreshLayerSelect() {
+function refreshLayerList() {
     if (!editor || typeof editor.layerCount !== 'number') return;
-    const layerSelect = document.querySelector('#layer-select');
-    if (!(layerSelect instanceof HTMLSelectElement)) return;
+    const layerList = document.querySelector('#layer-list');
+    if (!(layerList instanceof HTMLElement)) return;
+
+    // Clear list
+    while (layerList.firstChild) {
+        layerList.removeChild(layerList.firstChild);
+    }
+
     const count = editor.layerCount;
     const active = editor.activeLayer ?? 0;
-    while (layerSelect.firstChild) {
-        layerSelect.removeChild(layerSelect.firstChild);
-    }
-    for (let i = 0; i < count; i++) {
-        const opt = document.createElement('option');
-        opt.value = String(i);
-        opt.textContent = editor.layerName(i) || `Layer ${i + 1}`;
-        if (i === active) opt.selected = true;
-        layerSelect.appendChild(opt);
+
+    // Iterate through layers, displaying top layers first (index count - 1 to 0)
+    for (let i = count - 1; i >= 0; i--) {
+        const item = document.createElement('div');
+        item.className = 'layer-item';
+        if (i === active) item.classList.add('active');
+
+        // Select active layer on click
+        item.addEventListener('click', (e) => {
+            if (e.target instanceof HTMLButtonElement || e.target instanceof HTMLInputElement) {
+                return;
+            }
+            if (editor) {
+                editor.setActiveLayer(i);
+                requestRender();
+                updateUI();
+                scheduleAutoSave();
+            }
+        });
+
+        // Visibility Toggle Button
+        const visible = editor.layerVisible(i);
+        const visBtn = document.createElement('button');
+        visBtn.className = 'layer-item-btn';
+        if (visible) visBtn.classList.add('active');
+        visBtn.type = 'button';
+        visBtn.innerHTML = visible ? '👁' : '◌';
+        visBtn.title = visible ? 'Hide layer' : 'Show layer';
+        visBtn.setAttribute('aria-label', visible ? 'Hide layer' : 'Show layer');
+        visBtn.addEventListener('click', () => {
+            if (editor) {
+                editor.setLayerVisible(i, !visible);
+                requestRender();
+                updateUI();
+                scheduleAutoSave();
+            }
+        });
+
+        // Lock Toggle Button
+        const locked = editor.layerLocked(i);
+        const lockBtn = document.createElement('button');
+        lockBtn.className = 'layer-item-btn';
+        if (locked) lockBtn.classList.add('active');
+        lockBtn.type = 'button';
+        lockBtn.innerHTML = locked ? '🔒' : '🔓';
+        lockBtn.title = locked ? 'Unlock layer' : 'Lock layer';
+        lockBtn.setAttribute('aria-label', locked ? 'Unlock layer' : 'Lock layer');
+        lockBtn.addEventListener('click', () => {
+            if (editor) {
+                editor.setLayerLocked(i, !locked);
+                requestRender();
+                updateUI();
+                scheduleAutoSave();
+            }
+        });
+
+        // Layer Name Input
+        const nameInput = document.createElement('input');
+        nameInput.className = 'layer-name-input';
+        nameInput.type = 'text';
+        nameInput.value = editor.layerName(i) || `Layer ${i + 1}`;
+        nameInput.title = 'Edit layer name';
+        nameInput.addEventListener('change', () => {
+            if (editor) {
+                editor.renameLayer(i, nameInput.value);
+                scheduleAutoSave();
+            }
+        });
+
+        // Reorder Up Button
+        const upBtn = document.createElement('button');
+        upBtn.className = 'layer-item-btn';
+        upBtn.type = 'button';
+        upBtn.innerHTML = '↑';
+        upBtn.title = 'Move up';
+        upBtn.setAttribute('aria-label', 'Move up');
+        upBtn.disabled = i === count - 1;
+        upBtn.addEventListener('click', () => {
+            if (editor) {
+                editor.moveLayer(i, i + 1);
+                requestRender();
+                updateUI();
+                scheduleAutoSave();
+            }
+        });
+
+        // Reorder Down Button
+        const downBtn = document.createElement('button');
+        downBtn.className = 'layer-item-btn';
+        downBtn.type = 'button';
+        downBtn.innerHTML = '↓';
+        downBtn.title = 'Move down';
+        downBtn.setAttribute('aria-label', 'Move down');
+        downBtn.disabled = i === 0;
+        downBtn.addEventListener('click', () => {
+            if (editor) {
+                editor.moveLayer(i, i - 1);
+                requestRender();
+                updateUI();
+                scheduleAutoSave();
+            }
+        });
+
+        // Merge Down Button
+        const mergeBtn = document.createElement('button');
+        mergeBtn.className = 'layer-item-btn';
+        mergeBtn.type = 'button';
+        mergeBtn.innerHTML = '↴';
+        mergeBtn.title = 'Merge down';
+        mergeBtn.setAttribute('aria-label', 'Merge down');
+        mergeBtn.disabled = i === 0;
+        mergeBtn.addEventListener('click', () => {
+            if (editor) {
+                editor.mergeLayerDown(i);
+                requestRender();
+                updateUI();
+                scheduleAutoSave();
+                showToast('Merged layer down');
+            }
+        });
+
+        // Delete Button
+        const delBtn = document.createElement('button');
+        delBtn.className = 'layer-item-btn';
+        delBtn.type = 'button';
+        delBtn.innerHTML = '🗑';
+        delBtn.title = 'Delete layer';
+        delBtn.setAttribute('aria-label', 'Delete layer');
+        delBtn.disabled = count <= 1;
+        delBtn.addEventListener('click', () => {
+            if (editor) {
+                if (confirm('Delete this layer? This cannot be undone.')) {
+                    editor.deleteLayer(i);
+                    requestRender();
+                    updateUI();
+                    scheduleAutoSave();
+                    showToast('Layer deleted');
+                }
+            }
+        });
+
+        // Append everything
+        item.appendChild(visBtn);
+        item.appendChild(lockBtn);
+        item.appendChild(nameInput);
+        item.appendChild(upBtn);
+        item.appendChild(downBtn);
+        item.appendChild(mergeBtn);
+        item.appendChild(delBtn);
+
+        layerList.appendChild(item);
     }
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -373,8 +373,7 @@ body {
 }
 
 /* Grid size / layer controls */
-.grid-size-controls,
-.layer-controls {
+.grid-size-controls {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -403,9 +402,83 @@ body {
     outline-offset: 1px;
 }
 
-.layer-controls .select-input {
+/* Layer list styles */
+.layer-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    max-height: 220px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--spacing-xs);
+    background-color: var(--bg);
+}
+
+.layer-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs);
+    border-radius: var(--radius-sm);
+    background-color: transparent;
+    cursor: pointer;
+    transition: background-color var(--transition-fast);
+}
+
+.layer-item:hover {
+    background-color: var(--hover);
+}
+
+.layer-item.active {
+    background-color: var(--active);
+    border-left: 2px solid var(--accent);
+}
+
+.layer-name-input {
     flex: 1;
     min-width: 0;
+    background: transparent;
+    border: none;
+    color: var(--fg);
+    font-family: var(--font-family);
+    font-size: 11px;
+    padding: 2px var(--spacing-xs);
+}
+
+.layer-name-input:focus {
+    background-color: var(--bg-secondary);
+    outline: 1px solid var(--accent);
+    border-radius: var(--radius-sm);
+}
+
+.layer-item-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    cursor: pointer;
+    font-size: 12px;
+    border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+}
+
+.layer-item-btn:hover {
+    color: var(--fg);
+    background-color: var(--hover);
+}
+
+.layer-item-btn.active {
+    color: var(--accent);
+}
+
+.layer-item-btn:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
 }
 
 .visually-hidden {

--- a/web/style.css
+++ b/web/style.css
@@ -481,6 +481,16 @@ body {
     cursor: not-allowed;
 }
 
+.layer-actions {
+    margin-top: var(--spacing-sm);
+    display: flex;
+    gap: var(--spacing-xs);
+}
+
+.layer-actions .zoom-btn {
+    flex: 1;
+}
+
 .visually-hidden {
     position: absolute;
     width: 1px;

--- a/web/types.ts
+++ b/web/types.ts
@@ -58,6 +58,11 @@ export interface AsciiEditorInterface {
     setActiveLayer(index: number): boolean;
     addLayer(): number;
     renameLayer(index: number, name: string): void;
+    layerLocked(index: number): boolean;
+    setLayerLocked(index: number, locked: boolean): void;
+    deleteLayer(index: number): boolean;
+    moveLayer(from_index: number, to_index: number): void;
+    mergeLayerDown(index: number): boolean;
     getRenderCommands(): RenderCommand[];
     getDirtyRenderCommands(): RenderCommand[];
     getPixelBufferPtr(): number;

--- a/web/types.ts
+++ b/web/types.ts
@@ -61,7 +61,7 @@ export interface AsciiEditorInterface {
     layerLocked(index: number): boolean;
     setLayerLocked(index: number, locked: boolean): void;
     deleteLayer(index: number): boolean;
-    moveLayer(from_index: number, to_index: number): void;
+    moveLayer(fromIndex: number, toIndex: number): void;
     mergeLayerDown(index: number): boolean;
     getRenderCommands(): RenderCommand[];
     getDirtyRenderCommands(): RenderCommand[];


### PR DESCRIPTION
Implemented a complete layer editor on the ASCII Canvas with full interactive controls: lock/unlock layer to prevent edits, move up/down to reorder, rename, delete (with a guard for the last layer), and merge down with layer-specific undo/redo history preservation. All Rust unit tests and frontend tests pass successfully.

Fixes #111

---
*PR created automatically by Jules for task [3820810018958574798](https://jules.google.com/task/3820810018958574798) started by @d-o-hub*