### PR TITLE
Preview rendering with distinct style (F-15 / ADR-011)

### DIFF
--- a/src/render/canvas_renderer.rs
+++ b/src/render/canvas_renderer.rs
@@ -365,13 +365,10 @@ mod tests {
     fn test_build_full_render_with_preview() {
         let renderer = CanvasRenderer::new();
         let grid = Grid::new(10, 10);
-        let preview_ops = vec![crate::core::tools::DrawOp::new(
-            2,
-            3,
-            'X',
-        )];
+        let preview_ops = vec![crate::core::tools::DrawOp::new(2, 3, 'X')];
 
-        let commands = renderer.build_full_render_with_preview_and_selection(&grid, &preview_ops, None);
+        let commands =
+            renderer.build_full_render_with_preview_and_selection(&grid, &preview_ops, None);
 
         let mut found_preview = false;
         for cmd in commands {

--- a/src/render/canvas_renderer.rs
+++ b/src/render/canvas_renderer.rs
@@ -223,7 +223,7 @@ impl CanvasRenderer {
         for op in preview_ops {
             if op.cell.is_visible() {
                 let (sx, sy) = self.grid_to_screen(op.x, op.y);
-                commands.push(RenderCommand::DrawChar {
+                commands.push(RenderCommand::DrawPreviewChar {
                     x: sx,
                     y: sy + self.metrics.baseline * self.zoom,
                     char: op.cell.ch,
@@ -279,9 +279,24 @@ pub enum RenderCommand {
     SetFont { font: String, scale: f64 },
     /// Draw a character at position
     DrawChar {
+        /// X coordinate of the character
         x: f64,
+        /// Y coordinate of the character
         y: f64,
+        /// The character to draw
         char: char,
+        /// Font scaling factor
+        scale: f64,
+    },
+    /// Draw a preview character at position
+    DrawPreviewChar {
+        /// X coordinate of the preview character
+        x: f64,
+        /// Y coordinate of the preview character
+        y: f64,
+        /// The character to draw
+        char: char,
+        /// Font scaling factor
         scale: f64,
     },
     /// Draw a rectangle (for selection)
@@ -344,5 +359,27 @@ mod tests {
 
         let commands = renderer.build_render_commands(&grid, &dirty);
         assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn test_build_full_render_with_preview() {
+        let renderer = CanvasRenderer::new();
+        let grid = Grid::new(10, 10);
+        let preview_ops = vec![crate::core::tools::DrawOp::new(
+            2,
+            3,
+            'X',
+        )];
+
+        let commands = renderer.build_full_render_with_preview_and_selection(&grid, &preview_ops, None);
+
+        let mut found_preview = false;
+        for cmd in commands {
+            if let RenderCommand::DrawPreviewChar { char, .. } = cmd {
+                assert_eq!(char, 'X');
+                found_preview = true;
+            }
+        }
+        assert!(found_preview, "Should have found a DrawPreviewChar command");
     }
 }

--- a/src/render/font_renderer.rs
+++ b/src/render/font_renderer.rs
@@ -110,19 +110,19 @@ impl FontAtlas {
                         let pixel_idx = buffer_row_start + gx * 4;
 
                         if pixel_idx + 3 < buffer.len() {
-                            if mask == 255 {
+                            let effective_alpha = (mask as f32 / 255.0) * (color[3] as f32 / 255.0);
+                            if effective_alpha >= 1.0 {
                                 buffer[pixel_idx..pixel_idx + 3].copy_from_slice(&color[0..3]);
                             } else {
-                                let alpha = mask as f32 / 255.0;
-                                let inv_alpha = 1.0 - alpha;
+                                let inv_alpha = 1.0 - effective_alpha;
 
-                                buffer[pixel_idx] = (color_f[0] * alpha
+                                buffer[pixel_idx] = (color_f[0] * effective_alpha
                                     + buffer[pixel_idx] as f32 * inv_alpha)
                                     as u8;
-                                buffer[pixel_idx + 1] = (color_f[1] * alpha
+                                buffer[pixel_idx + 1] = (color_f[1] * effective_alpha
                                     + buffer[pixel_idx + 1] as f32 * inv_alpha)
                                     as u8;
-                                buffer[pixel_idx + 2] = (color_f[2] * alpha
+                                buffer[pixel_idx + 2] = (color_f[2] * effective_alpha
                                     + buffer[pixel_idx + 2] as f32 * inv_alpha)
                                     as u8;
                             }
@@ -332,5 +332,26 @@ mod tests {
         assert_eq!(buffer[5], (fg_color[1] as f32 * alpha) as u8);
         assert_eq!(buffer[6], (fg_color[2] as f32 * alpha) as u8);
         assert_eq!(buffer[7], 255);
+    }
+
+    #[test]
+    fn test_render_glyph_semi_transparent() {
+        let mut atlas = FontAtlas::new();
+        let mut custom_mask = vec![0u8; 8 * 20];
+        custom_mask[0] = 255; // Mask is opaque
+        atlas.update_glyph('?', &custom_mask);
+
+        let mut buffer = vec![0u8; 8 * 20 * 4];
+        let fg_color = [200, 100, 50, 128]; // Semi-transparent (approx 50% opacity)
+
+        atlas.render_glyph(&mut buffer, 8, 0, 0, '?', fg_color);
+
+        // effective_alpha = 1.0 * (128.0 / 255.0) approx 0.50196
+        let effective_alpha = 128.0 / 255.0;
+        // Background is 0, so expected = fg_color * effective_alpha
+        assert_eq!(buffer[0], (fg_color[0] as f32 * effective_alpha) as u8);
+        assert_eq!(buffer[1], (fg_color[1] as f32 * effective_alpha) as u8);
+        assert_eq!(buffer[2], (fg_color[2] as f32 * effective_alpha) as u8);
+        assert_eq!(buffer[3], 255);
     }
 }

--- a/src/wasm/render_api.rs
+++ b/src/wasm/render_api.rs
@@ -348,6 +348,7 @@ impl AsciiEditor {
             }
         }
 
+        let preview_color = [86, 156, 214, 179]; // rgba(86, 156, 214, 0.7)
         for op in &self.preview_ops {
             if op.cell.is_visible() {
                 self.font_atlas.render_glyph(
@@ -356,7 +357,7 @@ impl AsciiEditor {
                     op.x as usize * glyph_w,
                     op.y as usize * glyph_h,
                     op.cell.ch,
-                    fg_color,
+                    preview_color,
                 );
             }
         }

--- a/web/main.ts
+++ b/web/main.ts
@@ -972,6 +972,11 @@ function executeRenderCommand(cmd: RenderCommand) {
             ctx.fillText(cmd.char as string, cmd.x as number, cmd.y as number);
             break;
 
+        case 'DrawPreviewChar':
+            ctx.fillStyle = 'rgba(86, 156, 214, 0.7)';
+            ctx.fillText(cmd.char as string, cmd.x as number, cmd.y as number);
+            break;
+
         case 'DrawRect':
             ctx.fillStyle = cmd.color as string || '#264f78';
             ctx.fillRect(cmd.x as number, cmd.y as number, cmd.width as number, cmd.height as number);


### PR DESCRIPTION
This PR implements ADR-011 (Preview Operations Rendering), adding distinct preview rendering styles (blue tint with semi-transparency) to both the traditional canvas path and the composite pixel buffer path. Tests have been updated and are fully passing.

Fixes #113

---
*PR created automatically by Jules for task [2264759946277318783](https://jules.google.com/task/2264759946277318783) started by @d-o-hub*