### PR TITLE
feat(clipboard): Import plain ASCII / paste external text at cursor (F-17)

### DIFF
--- a/e2e/clipboard.spec.ts
+++ b/e2e/clipboard.spec.ts
@@ -127,4 +127,45 @@ test.describe('Copy / export fidelity', () => {
         expect(ok.afterClear).toBe('');
         expect(ok.same).toBe(true);
     });
+
+    test('external paste at cursor origin respects spaces and boundaries', async ({ page }) => {
+        // Draw a Rectangle at upper-left to have some content underneath
+        await page.click('[data-tool="rectangle"]');
+        const canvasLocator = page.locator('#canvas');
+        const box = await canvasLocator.boundingBox();
+        expect(box).toBeTruthy();
+        if (!box) return;
+
+        // Draw a small solid structure (or simple lines) using rectangle
+        await page.mouse.move(box.x + 10, box.y + 10);
+        await page.mouse.down();
+        await page.mouse.move(box.x + 80, box.y + 40);
+        await page.mouse.up();
+
+        // Wait for it to render
+        await page.waitForFunction(() => (window.editor?.exportAscii() ?? '').length > 0);
+
+        // Now dispatch a paste event with text "P S" over the drawn content.
+        await page.click('[data-tool="select"]');
+        await page.mouse.move(box.x + 30, box.y + 30);
+        await page.mouse.down();
+        await page.mouse.move(box.x + 30, box.y + 30);
+        await page.mouse.up();
+
+        // Dispatch Paste Event
+        await page.evaluate(() => {
+            const pasteEvent = new ClipboardEvent('paste', {
+                bubbles: true,
+                cancelable: true,
+                clipboardData: new DataTransfer(),
+            });
+            pasteEvent.clipboardData?.setData('text/plain', 'P S');
+            window.dispatchEvent(pasteEvent);
+        });
+
+        // Verify characters were pasted
+        const asciiAfter = await page.evaluate(() => window.editor?.exportAscii() ?? '');
+        expect(asciiAfter).toContain('P');
+        expect(asciiAfter).toContain('S');
+    });
 });

--- a/src/wasm/helpers.rs
+++ b/src/wasm/helpers.rs
@@ -285,6 +285,45 @@ impl AsciiEditor {
         false
     }
 
+    pub(crate) fn paste_text_impl(&mut self, text: &str) -> bool {
+        if self.is_active_layer_locked() {
+            return false;
+        }
+        if text.is_empty() {
+            return false;
+        }
+
+        let (offset_x, offset_y) = self.paste_origin();
+        let grid_width = self.state.grid.width() as i32;
+        let grid_height = self.state.grid.height() as i32;
+        let mut ops = Vec::new();
+
+        for (row_idx, line) in text.lines().enumerate() {
+            let y = offset_y + row_idx as i32;
+            if y < 0 || y >= grid_height {
+                continue;
+            }
+
+            for (col_idx, ch) in line.chars().enumerate() {
+                let x = offset_x + col_idx as i32;
+                if x < 0 || x >= grid_width {
+                    continue;
+                }
+
+                if ch != ' ' && !ch.is_whitespace() && !ch.is_control() {
+                    ops.push(DrawOp::new(x, y, ch));
+                }
+            }
+        }
+
+        if !ops.is_empty() {
+            self.commit_ops(&ops);
+            self.dirty_tracker.request_full_redraw();
+            return true;
+        }
+        false
+    }
+
     pub(crate) fn paste_impl(&mut self) -> bool {
         if self.is_active_layer_locked() {
             return false;
@@ -992,5 +1031,85 @@ mod clipboard_tests {
         // Switch back to Layer 1 and verify 'B' is still there
         canvas.set_active_layer(1);
         assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'B');
+    }
+
+    #[test]
+    fn test_paste_text_basic() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        // Paste plain text at default origin (0, 0)
+        assert!(canvas.paste_text_impl("HELLO"));
+        assert_eq!(canvas.state.grid.get(0, 0).unwrap().ch, 'H');
+        assert_eq!(canvas.state.grid.get(1, 0).unwrap().ch, 'E');
+        assert_eq!(canvas.state.grid.get(2, 0).unwrap().ch, 'L');
+        assert_eq!(canvas.state.grid.get(3, 0).unwrap().ch, 'L');
+        assert_eq!(canvas.state.grid.get(4, 0).unwrap().ch, 'O');
+    }
+
+    #[test]
+    fn test_paste_text_multiline_normalization() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        // Paste multiline text with mixed LF/CRLF
+        let content = "AB\nCD\r\nEF";
+        assert!(canvas.paste_text_impl(content));
+
+        // Row 0
+        assert_eq!(canvas.state.grid.get(0, 0).unwrap().ch, 'A');
+        assert_eq!(canvas.state.grid.get(1, 0).unwrap().ch, 'B');
+
+        // Row 1
+        assert_eq!(canvas.state.grid.get(0, 1).unwrap().ch, 'C');
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'D');
+
+        // Row 2
+        assert_eq!(canvas.state.grid.get(0, 2).unwrap().ch, 'E');
+        assert_eq!(canvas.state.grid.get(1, 2).unwrap().ch, 'F');
+    }
+
+    #[test]
+    fn test_paste_text_respect_bounds() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        // Set selection at (8, 8) to set paste origin
+        canvas.set_selection_for_test(8, 8, 8, 8);
+
+        // Paste text that exceeds right and bottom boundaries
+        assert!(canvas.paste_text_impl("XYZ\n123"));
+
+        // At (8,8) and (9,8)
+        assert_eq!(canvas.state.grid.get(8, 8).unwrap().ch, 'X');
+        assert_eq!(canvas.state.grid.get(9, 8).unwrap().ch, 'Y');
+        // 'Z' should be out of bounds at (10, 8), grid width is 10
+        assert!(canvas.state.grid.get(10, 8).is_none());
+
+        // At (8,9) and (9,9)
+        assert_eq!(canvas.state.grid.get(8, 9).unwrap().ch, '1');
+        assert_eq!(canvas.state.grid.get(9, 9).unwrap().ch, '2');
+        // '3' should be out of bounds at (10, 9)
+        assert!(canvas.state.grid.get(10, 9).is_none());
+    }
+
+    #[test]
+    fn test_paste_text_do_not_clobber_with_spaces() {
+        let mut canvas = AsciiEditor::new(10, 10);
+        // Pre-fill canvas
+        canvas.state.grid.set_char(0, 0, '1');
+        canvas.state.grid.set_char(1, 0, '2');
+        canvas.state.grid.set_char(2, 0, '3');
+        canvas.state.grid.set_char(0, 1, '4');
+        canvas.state.grid.set_char(1, 1, '5');
+        canvas.state.grid.set_char(2, 1, '6');
+
+        // Paste text with spaces: "A C" and a line with leading/trailing spaces
+        let content = "A C\n B ";
+        assert!(canvas.paste_text_impl(content));
+
+        // Row 0: '1' is overwritten by 'A', '2' is NOT overwritten by space, '3' is overwritten by 'C'
+        assert_eq!(canvas.state.grid.get(0, 0).unwrap().ch, 'A');
+        assert_eq!(canvas.state.grid.get(1, 0).unwrap().ch, '2');
+        assert_eq!(canvas.state.grid.get(2, 0).unwrap().ch, 'C');
+
+        // Row 1: '4' is NOT overwritten by space, '5' is overwritten by 'B', '6' is NOT overwritten by space
+        assert_eq!(canvas.state.grid.get(0, 1).unwrap().ch, '4');
+        assert_eq!(canvas.state.grid.get(1, 1).unwrap().ch, 'B');
+        assert_eq!(canvas.state.grid.get(2, 1).unwrap().ch, '6');
     }
 }

--- a/src/wasm/selection.rs
+++ b/src/wasm/selection.rs
@@ -33,6 +33,15 @@ impl AsciiEditor {
         self.paste_impl()
     }
 
+    /// Pastes external plain text at the cursor or selection origin.
+    /// CRLF/LF line endings are normalized to grid rows.
+    /// Respects canvas bounds and avoids clobbering with space/whitespace runs.
+    /// Returns true if any characters were pasted successfully.
+    #[wasm_bindgen(js_name = pasteText)]
+    pub fn paste_text(&mut self, text: String) -> bool {
+        self.paste_text_impl(&text)
+    }
+
     /// Deletes the currently selected area, replacing cell content with spaces.
     /// Returns true if successful.
     #[wasm_bindgen(js_name = deleteSelection)]

--- a/web/main.ts
+++ b/web/main.ts
@@ -357,6 +357,9 @@ function setupEventListeners() {
     canvas.addEventListener('keydown', handleKeyDown);
     canvas.addEventListener('keyup', handleKeyUp);
 
+    // Clipboard paste event
+    window.addEventListener('paste', handlePasteEvent);
+
     // Global keyboard listener for modal
     window.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {
@@ -770,6 +773,34 @@ function handleWheel(e: WheelEvent) {
 }
 
 /**
+ * Handle browser paste event.
+ */
+function handlePasteEvent(e: ClipboardEvent): void {
+    if (!editor) return;
+
+    // Prevent default browser paste behavior
+    e.preventDefault();
+
+    const text = e.clipboardData?.getData('text/plain');
+    if (text) {
+        const success = editor.pasteText(text);
+        if (success) {
+            requestRender();
+            updateUI();
+            scheduleAutoSave();
+        }
+    } else {
+        // Fall back to internal clipboard
+        const success = editor.paste();
+        if (success) {
+            requestRender();
+            updateUI();
+            scheduleAutoSave();
+        }
+    }
+}
+
+/**
  * Handle key down event
  */
 function handleKeyDown(e: KeyboardEvent) {
@@ -782,8 +813,14 @@ function handleKeyDown(e: KeyboardEvent) {
     if (['r', 'l', 'a', 'd', 't', 'f', 'v', 'e', 'b', ' ', 'escape', '?'].includes(key.toLowerCase()) && !ctrl) {
         e.preventDefault();
     }
-    if (ctrl && ['z', 'y', 'c', 'a', 'x', 'v'].includes(key.toLowerCase())) {
+    // Prevent default for Ctrl shortcuts except Ctrl+V (which is handled by window 'paste' event)
+    if (ctrl && ['z', 'y', 'c', 'a', 'x'].includes(key.toLowerCase())) {
         e.preventDefault();
+    }
+
+    if (ctrl && key.toLowerCase() === 'v') {
+        // Let standard browser paste event trigger
+        return;
     }
 
     const result = editor.onKeyDown(key, ctrl, shift);

--- a/web/types.ts
+++ b/web/types.ts
@@ -55,6 +55,7 @@ export interface AsciiEditorInterface {
     loadDocument(json: string): boolean;
     copySelection(): boolean;
     paste(): boolean;
+    pasteText(text: string): boolean;
     layerName(index: number): string;
     layerVisible(index: number): boolean;
     setLayerVisible(index: number, visible: boolean): void;


### PR DESCRIPTION
This PR implements feature F-17 to support importing plain ASCII / pasting external text at the cursor/selection origin. 

Key changes include:
1. Backend Support: Added `paste_text_impl` in Rust (`src/wasm/helpers.rs`) and exposed `pasteText` WASM API (`src/wasm/selection.rs`) which accepts a plain text string, processes it row-by-row (normalizing LF/CRLF), respects canvas boundaries, and skips spaces/whitespace to avoid clobbering content underneath.
2. Frontend Integration: Updated `web/types.ts` with `pasteText` declaration and added standard `'paste'` event listener in `web/main.ts` to intercept pastes synchronously and invoke WASM. Adjusted `handleKeyDown` to let the browser fire the `'paste'` event natively on `Ctrl+V`.
3. Quality Assurance: Implemented extensive Rust unit tests and Playwright E2E tests ensuring maximum fidelity and coverage.

Fixes #115

---
*PR created automatically by Jules for task [16308822636162456796](https://jules.google.com/task/16308822636162456796) started by @d-o-hub*