### PR TITLE
Make wasm-opt (binaryen) reliable in CI and document mise install (F-24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Build WASM
         run: |
-          npm install -g wasm-opt
+          pnpm install --frozen-lockfile
           pnpm run build:wasm
 
       - name: WASM size budget

--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ A **production-grade ASCII diagram editor** built with Rust and WebAssembly. Fea
 - [Rust](https://rustup.rs/) (1.75+)
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) (0.13.1+)
 - [Node.js](https://nodejs.org/) (22+)
-- **Toolchain Manager (Recommended)**: [mise-en-place (mise)](https://mise.jdx.dev/) is used to automatically manage and pin toolchain versions (Node.js, Rust, wasm-bindgen-cli, and binaryen/wasm-opt) defined in `mise.toml`.
-  - Install mise by following the [mise installation instructions](https://mise.jdx.dev/getting-started.html).
-  - Run `mise install` in the project root to install all required tools automatically.
-- **WASM Optimizer**: [binaryen (`wasm-opt`)](https://github.com/WebAssembly/binaryen) is **required** to compile optimized release builds of the WASM module.
-  - If using `mise`, it is automatically installed as part of the toolchain setup (defined in `mise.toml`).
-  - Alternatively, you can install it globally via npm using the canonical `binaryen` package: `npm install -g binaryen`.
-  - Or manually install the `binaryen` package via your system package manager (e.g., `brew install binaryen` or `apt-get install binaryen`).
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ A **production-grade ASCII diagram editor** built with Rust and WebAssembly. Fea
   - Install mise by following the [mise installation instructions](https://mise.jdx.dev/getting-started.html).
   - Run `mise install` in the project root to install all required tools automatically.
 - **WASM Optimizer**: [binaryen (`wasm-opt`)](https://github.com/WebAssembly/binaryen) is **required** to compile optimized release builds of the WASM module.
-  - If using `mise`, it is automatically installed as part of the toolchain setup.
-  - Alternatively, you can install it globally via npm: `npm install -g wasm-opt`.
+  - If using `mise`, it is automatically installed as part of the toolchain setup (defined in `mise.toml`).
+  - Alternatively, you can install it globally via npm using the canonical `binaryen` package: `npm install -g binaryen`.
   - Or manually install the `binaryen` package via your system package manager (e.g., `brew install binaryen` or `apt-get install binaryen`).
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ A **production-grade ASCII diagram editor** built with Rust and WebAssembly. Fea
 - [Rust](https://rustup.rs/) (1.75+)
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) (0.13.1+)
 - [Node.js](https://nodejs.org/) (22+)
+- **Toolchain Manager (Recommended)**: [mise-en-place (mise)](https://mise.jdx.dev/) is used to automatically manage and pin toolchain versions (Node.js, Rust, wasm-bindgen-cli, and binaryen/wasm-opt) defined in `mise.toml`.
+  - Install mise by following the [mise installation instructions](https://mise.jdx.dev/getting-started.html).
+  - Run `mise install` in the project root to install all required tools automatically.
+- **WASM Optimizer**: [binaryen (`wasm-opt`)](https://github.com/WebAssembly/binaryen) is **required** to compile optimized release builds of the WASM module.
+  - If using `mise`, it is automatically installed as part of the toolchain setup.
+  - Alternatively, you can install it globally via npm: `npm install -g wasm-opt`.
+  - Or manually install the `binaryen` package via your system package manager (e.g., `brew install binaryen` or `apt-get install binaryen`).
 
 ### Build
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/d-o-hub/rust-ascii-canvas#readme",
   "scripts": {
-    "build:wasm": "cargo build --target wasm32-unknown-unknown --release && wasm-bindgen target/wasm32-unknown-unknown/release/ascii_canvas.wasm --out-dir web/pkg --target web && (command -v wasm-opt >/dev/null && wasm-opt --enable-simd --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -O3 web/pkg/ascii_canvas_bg.wasm -o web/pkg/ascii_canvas_bg.wasm || echo 'wasm-opt not found; skipping optimization')",
+    "build:wasm": "cargo build --target wasm32-unknown-unknown --release && wasm-bindgen target/wasm32-unknown-unknown/release/ascii_canvas.wasm --out-dir web/pkg --target web && (if command -v wasm-opt >/dev/null; then wasm-opt --enable-simd --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -O3 web/pkg/ascii_canvas_bg.wasm -o web/pkg/ascii_canvas_bg.wasm; elif [ \"$CI\" = \"true\" ]; then echo 'Error: wasm-opt is required in CI but not found.' >&2; exit 1; elif [ \"$SKIP_WASM_OPT\" = \"1\" ]; then echo 'wasm-opt not found; skipping optimization (SKIP_WASM_OPT=1)'; else echo 'Error: wasm-opt is not installed.' >&2; echo 'To install wasm-opt, use mise or npm: npm install -g wasm-opt' >&2; echo 'To bypass optimization, run with SKIP_WASM_OPT=1' >&2; exit 1; fi)",
     "build:web": "cd web && pnpm run build",
     "build": "pnpm run build:wasm && pnpm run build:web",
     "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.126 && npm install -g wasm-opt && pnpm install --frozen-lockfile && cd web && pnpm install --frozen-lockfile && cd .. && pnpm run build && pnpm run check-size",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/d-o-hub/rust-ascii-canvas#readme",
   "scripts": {
-    "build:wasm": "cargo build --target wasm32-unknown-unknown --release && wasm-bindgen target/wasm32-unknown-unknown/release/ascii_canvas.wasm --out-dir web/pkg --target web && (if command -v wasm-opt >/dev/null; then wasm-opt --enable-simd --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -O3 web/pkg/ascii_canvas_bg.wasm -o web/pkg/ascii_canvas_bg.wasm; elif [ \"$CI\" = \"true\" ]; then echo 'Error: wasm-opt is required in CI but not found.' >&2; exit 1; elif [ \"$SKIP_WASM_OPT\" = \"1\" ]; then echo 'wasm-opt not found; skipping optimization (SKIP_WASM_OPT=1)'; else echo 'Error: wasm-opt is not installed.' >&2; echo 'To install wasm-opt, use mise or npm: npm install -g wasm-opt' >&2; echo 'To bypass optimization, run with SKIP_WASM_OPT=1' >&2; exit 1; fi)",
+    "build:wasm": "bash scripts/build-wasm.sh",
     "build:web": "cd web && pnpm run build",
     "build": "pnpm run build:wasm && pnpm run build:web",
-    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.126 && npm install -g wasm-opt && pnpm install --frozen-lockfile && cd web && pnpm install --frozen-lockfile && cd .. && pnpm run build && pnpm run check-size",
+    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.126 && npm install -g binaryen && pnpm install --frozen-lockfile && cd web && pnpm install --frozen-lockfile && cd .. && pnpm run build && pnpm run check-size",
     "dev": "cd web && pnpm run dev",
     "test": "cargo test && npx playwright test --project=chromium",
     "test:unit": "cargo test",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:wasm": "bash scripts/build-wasm.sh",
     "build:web": "cd web && pnpm run build",
     "build": "pnpm run build:wasm && pnpm run build:web",
-    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.126 && npm install -g binaryen && pnpm install --frozen-lockfile && cd web && pnpm install --frozen-lockfile && cd .. && pnpm run build && pnpm run check-size",
+    "netlify:build": "rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.126 && pnpm install --frozen-lockfile && cd web && pnpm install --frozen-lockfile && cd .. && pnpm run build && pnpm run check-size",
     "dev": "cd web && pnpm run dev",
     "test": "cargo test && npx playwright test --project=chromium",
     "test:unit": "cargo test",
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
+    "binaryen": "^131.0.0",
     "eslint": "^10.7.0",
     "playwright": "^1.61.1",
     "typescript-eslint": "^8.64.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      binaryen:
+        specifier: ^131.0.0
+        version: 131.0.0
       eslint:
         specifier: ^10.7.0
         version: 10.7.0
@@ -174,6 +177,10 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  binaryen@131.0.0:
+    resolution: {integrity: sha512-anblNezmBjfWGfOMvZq1j5MwhVnMs+gezqbDz4FBFwx6twDwOsQSed+E8i4UKmLYXb3r+f3HWmz7Lx5sx5qOyQ==}
+    hasBin: true
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -600,6 +607,8 @@ snapshots:
       uri-js: 4.4.1
 
   balanced-match@4.0.4: {}
+
+  binaryen@131.0.0: {}
 
   brace-expansion@5.0.7:
     dependencies:

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/build-wasm.sh
+# Builds the WASM target and runs wasm-opt to optimize the binary.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "Building WASM target..."
+cargo build --target wasm32-unknown-unknown --release
+
+echo "Generating WASM bindings..."
+wasm-bindgen target/wasm32-unknown-unknown/release/ascii_canvas.wasm --out-dir web/pkg --target web
+
+WASM_FILE="web/pkg/ascii_canvas_bg.wasm"
+
+if command -v wasm-opt >/dev/null; then
+  echo "Optimizing WASM binary with wasm-opt..."
+  wasm-opt --enable-simd --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -O3 "$WASM_FILE" -o "$WASM_FILE"
+  echo "WASM optimization complete."
+else
+  # If GITHUB_ACTIONS is "true" or CI is "true"
+  if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ "${CI:-}" = "true" ]; then
+    echo "==========================================================" >&2
+    echo " ERROR: wasm-opt is REQUIRED in CI but was not found!" >&2
+    echo " Ensure binaryen (wasm-opt) is installed in your runner." >&2
+    echo "==========================================================" >&2
+    exit 1
+  elif [ "${SKIP_WASM_OPT:-}" = "1" ]; then
+    echo "=========================================================="
+    echo " WARNING: wasm-opt not found!"
+    echo " Skipping optimization because SKIP_WASM_OPT=1 is set."
+    echo " THIS BINARY IS NOT OPTIMIZED FOR PRODUCTION."
+    echo "=========================================================="
+  else
+    echo "==========================================================" >&2
+    echo " ERROR: wasm-opt (binaryen) is not installed." >&2
+    echo " To ensure size and performance parity with CI, install wasm-opt." >&2
+    echo "   - Via mise (recommended): run 'mise install'" >&2
+    echo "   - Via npm: run 'npm install -g binaryen'" >&2
+    echo "   - Via package manager: e.g. 'brew install binaryen' or 'apt install binaryen'" >&2
+    echo "" >&2
+    echo " If you must build without wasm-opt, run with SKIP_WASM_OPT=1:" >&2
+    echo "   SKIP_WASM_OPT=1 pnpm run build:wasm" >&2
+    echo "==========================================================" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
This change enforces that wasm-opt is executed during the build:wasm script. In CI, if wasm-opt is missing, the build fails immediately. In local environments, if wasm-opt is missing, the build fails with a helpful instruction on how to install it via mise or npm, or how to bypass it with SKIP_WASM_OPT=1. It also updates the README.md to document the mise installation instructions and prerequisites.

Fixes #120

---
*PR created automatically by Jules for task [3911278845857786236](https://jules.google.com/task/3911278845857786236) started by @d-o-hub*