### PR TITLE
chore(release): document app-only distribution (F-33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,19 @@ npm run build
 ```
 The final static assets will be in the `dist/` directory.
 
+### Library vs. App-Only Distribution
+
+ASCII Canvas is designed and distributed exclusively as an **app-only** project (an end-user single-page web application).
+
+While the project is organized with a Rust/WASM backend (`src/`) and a TypeScript frontend (`web/`), these components are tightly coupled and highly optimized specifically for this application (e.g., custom dirty-rect rendering and font atlas glyph rasterization).
+
+Therefore:
+- **No crates.io release**: The crate is not published to crates.io as a reusable Rust library.
+- **No npm registry release**: The compiled WASM package is not published to the public npm registry as a reusable package.
+- **Static Asset Deployment**: All standard deployments are done by hosting the static web assets from the `/dist` directory (for example, on Netlify or similar hosting platforms).
+
+See [ADR-040 (App-Only Distribution)](plans/ADRs/040-app-only-distribution.md) for further technical context and rationale.
+
 ## Performance
 
 - **Dirty-Rect Rendering**: Only redraws modified regions, significantly reducing CPU usage during edits.

--- a/plans/ADRs/040-app-only-distribution.md
+++ b/plans/ADRs/040-app-only-distribution.md
@@ -1,0 +1,48 @@
+# ADR-040: App-Only Distribution — crates.io / npm Publishing Decision
+
+## Status
+Accepted - 2026-07-28
+
+## Context
+
+Under issue **F-33** (crates.io / npm package metadata), the project was tasked with deciding whether to publish the core Rust crate and/or npm packages to their respective public registries, or explicitly designate and document the project as an **"app-only"** distribution.
+
+Currently:
+- The project has a standard root structure with `Cargo.toml` representing the Rust-to-WASM portion and `package.json` representing the workspace dependencies and helper scripts.
+- The `web/` directory contains a fully featured, single-page static web application built using Vite, TypeScript, and the compiled WASM module.
+- `Cargo.toml` contains some package metadata (version `0.1.1`, description, license, repository, etc.), as do the root and web `package.json` files.
+
+## Decision
+
+We decide **not** to publish `ascii-canvas` as a reusable library crate on crates.io or as a reusable npm library package. Instead, we formally designate the project as an **"app-only" distribution**.
+
+The primary artifact of this repository is the deployed ASCII Canvas Editor web application. It is distributed exclusively as a hosted static website (e.g., via Netlify or local production build in `dist/`), not as a library for external consumption.
+
+## Rationale
+
+1. **Monolithic Design & Strong Coupling**:
+   The WASM bindings (`src/wasm/`), custom pixel-buffer rendering pipeline, dirty-rect tracking, and front-end font atlas logic are highly specific, custom-tailored, and tightly integrated with the browser-based Vite application in `/web`. They are not designed to serve as a general-purpose, reusable Rust drawing library or standard WASM diagramming package.
+
+2. **No Clear Consumer Base**:
+   Publishing `ascii-canvas` on crates.io or npm would result in package packages that provide very little value to general developers, as the APIs are geared specifically toward powering our own dark-themed Figma-like diagramming UI.
+
+3. **Maintenance Overhead**:
+   Supporting public package registry releases requires extensive version management, keeping public API surfaces stable, managing backward compatibility, and managing registry credentials and CI pipelines. Given that the goal is an end-user application, this overhead is not justified.
+
+4. **Clarity for Contributors**:
+   Documenting this decision clearly prevents future contributors from attempting to refactor the workspace in anticipation of a dual-library publication model.
+
+## Consequences
+
+- **Backlog & Issue Closure**:
+  Issue **F-33** is closed as `wontfix (app-only)`.
+- **Repository Metadata**:
+  The existing metadata in `Cargo.toml` and `package.json` (such as repo URLs, authors, descriptions, licenses) remains accurate for repository visibility but will not be used for publishing.
+- **Distribution Method**:
+  Static-asset hosting remains the single target distribution method, as currently implemented with Netlify (`netlify.toml`) and local standard builds (`npm run build`).
+- **No Registry Publish**:
+  No `cargo publish` or `npm publish` workflows will be established or run.
+
+## References
+- [F-33 Backlog Item](./../FOLLOW_UPS.md)
+- [ADR-005b: Package Metadata Consistency](./005b-package-metadata-consistency.md)

--- a/plans/FOLLOW_UPS.md
+++ b/plans/FOLLOW_UPS.md
@@ -57,7 +57,7 @@ Use this list for prioritization. Mark items done in-place and mirror major comp
 | **F-30** | spike | [#124](https://github.com/d-o-hub/rust-ascii-canvas/issues/124) | Collab editing research spike complete; documented in `plans/F-30-collaborative-editing-spike.md` |
 | **F-31** | open | [#125](https://github.com/d-o-hub/rust-ascii-canvas/issues/125) | Light theme + switcher |
 | **F-32** | open | [#126](https://github.com/d-o-hub/rust-ascii-canvas/issues/126) | Mobile UX audit |
-| **F-33** | open | [#127](https://github.com/d-o-hub/rust-ascii-canvas/issues/127) | crates.io / npm publish decision |
+| **F-33** | wontfix | [#127](https://github.com/d-o-hub/rust-ascii-canvas/issues/127) | App-only distribution chosen; documented in ADR-040 |
 
 ---
 

--- a/plans/PROJECT_STATUS.md
+++ b/plans/PROJECT_STATUS.md
@@ -53,7 +53,10 @@ A production-grade Rust/WASM ASCII diagram editor with a dark Figma-like UI.
 
 ---
 
-## Recent Completions (2026-07-15 → 2026-07-16)
+## Recent Completions (2026-07-15 → 2026-07-28)
+
+### F-33: crates.io / npm package metadata / publishing decision (2026-07-28) ✅
+- Decided on **app-only** distribution (no public library releases on crates.io or npm). Documented in [ADR-040](ADRs/040-app-only-distribution.md).
 
 ### F-02: Manual Clipboard Fidelity QA across Editors (2026-07-16) ✅
 - **Draw box + arrow** verified: drew on canvas, hit Copy, confirmed clipboard contains right borders (┐, │, ┘, etc.), uniform line widths, and CRLF (`\r\n`) endings.
@@ -135,4 +138,4 @@ ascii-canvas/
 
 ---
 
-*Last updated: 2026-07-16*
+*Last updated: 2026-07-28*


### PR DESCRIPTION
Formally decided to treat ASCII Canvas as an app-only distribution. Documented the decision in README.md, added ADR-040, and updated the project status and backlog accordingly.

Fixes #127

---
*PR created automatically by Jules for task [81257810679217743](https://jules.google.com/task/81257810679217743) started by @d-o-hub*