### PR TITLE
fix(ci): remove non-existent label from release PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,8 +277,7 @@ jobs:
             --title "chore(release): update changelog for v$VERSION" \
             --body "Automated changelog update for v$VERSION release." \
             --base main \
-            --head "$BRANCH_NAME" \
-            --label "automated")
+            --head "$BRANCH_NAME")
           
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "Created PR #$PR_NUMBER: $PR_URL"


### PR DESCRIPTION
Removes `--label "automated"` from `gh pr create` in release workflow. The label does not exist in the repo, causing the workflow to fail.