### PR TITLE
fix(ci): delete stale release branch before creating new one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,8 +277,7 @@ jobs:
             --title "chore(release): update changelog for v$VERSION" \
             --body "Automated changelog update for v$VERSION release." \
             --base main \
-            --head "$BRANCH_NAME" \
-            --label "automated")
+            --head "$BRANCH_NAME")
           
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "Created PR #$PR_NUMBER: $PR_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,9 @@ jobs:
             exit 0
           fi
           
+          # Delete remote branch if it exists (from a previous failed run)
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+          
           git commit -m "chore(release): update changelog and VERSION to $VERSION"
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"


### PR DESCRIPTION
Fixes release workflow to delete the remote `release/vX.Y.Z-changelog` branch if it exists from a previous failed run, before creating a new one.