### PR TITLE
🎨 Palette: Dynamic Screen-Reader Labeling for State Switches

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,4 +32,4 @@
 
 ## 2026-08-13 - [Dynamic Screen-Reader Labeling for Interactive State Switches]
 **Learning:** Interactive list-actions (such as moving up, down, or deleting layers) as well as global actions (like undo and redo) are often dynamically disabled/enabled. Simply setting `disabled` is not enough for modern micro-interactions; screen readers and mouse hovers need descriptive contextual reasons explaining why the control is currently locked.
-**Action:** Dynamically assign localized, descriptive `title` and `aria-label` tags corresponding to the active or disabled state (e.g., 'Nothing to undo' or 'Cannot move the top layer further up') rather than static labels.
+**Action:** Dynamically assign descriptive `title` and `aria-label` tags corresponding to the active or disabled state (e.g., 'Nothing to undo' or 'Cannot move the top layer further up') rather than static labels.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-07-10 - [Centering Logic and Robust Shortcuts]
 **Learning:** Centering the grid content in the viewport after zoom or fit-to-view actions significantly improves the professional feel and interaction quality of the editor. Furthermore, providing character-based fallbacks for shortcuts (e.g., handling ')' for Shift+0) ensures that keyboard interactions remain accessible across different international keyboard layouts.
 **Action:** Always calculate centering pan offsets when modifying canvas scale and implement character-level checks for shortcuts that involve Shift or Alt modifiers.
+
+## 2026-08-13 - [Dynamic Screen-Reader Labeling for Interactive State Switches]
+**Learning:** Interactive list-actions (such as moving up, down, or deleting layers) as well as global actions (like undo and redo) are often dynamically disabled/enabled. Simply setting `disabled` is not enough for modern micro-interactions; screen readers and mouse hovers need descriptive contextual reasons explaining why the control is currently locked.
+**Action:** Dynamically assign localized, descriptive `title` and `aria-label` tags corresponding to the active or disabled state (e.g., 'Nothing to undo' or 'Cannot move the top layer further up') rather than static labels.

--- a/web/ui.ts
+++ b/web/ui.ts
@@ -336,9 +336,10 @@ export function refreshLayerList(): void {
         upBtn.className = 'layer-item-btn';
         upBtn.type = 'button';
         upBtn.textContent = '↑';
-        upBtn.title = 'Move up';
-        upBtn.setAttribute('aria-label', 'Move up');
-        upBtn.disabled = i === count - 1;
+        const isTopLayer = i === count - 1;
+        upBtn.title = isTopLayer ? 'Cannot move the top layer further up' : 'Move up';
+        upBtn.setAttribute('aria-label', isTopLayer ? 'Cannot move the top layer further up' : 'Move up');
+        upBtn.disabled = isTopLayer;
         upBtn.addEventListener('click', () => {
             if (state.editor) {
                 state.editor.moveLayer(i, i + 1);
@@ -352,9 +353,10 @@ export function refreshLayerList(): void {
         downBtn.className = 'layer-item-btn';
         downBtn.type = 'button';
         downBtn.textContent = '↓';
-        downBtn.title = 'Move down';
-        downBtn.setAttribute('aria-label', 'Move down');
-        downBtn.disabled = i === 0;
+        const isBottomLayer = i === 0;
+        downBtn.title = isBottomLayer ? 'Cannot move the bottom layer further down' : 'Move down';
+        downBtn.setAttribute('aria-label', isBottomLayer ? 'Cannot move the bottom layer further down' : 'Move down');
+        downBtn.disabled = isBottomLayer;
         downBtn.addEventListener('click', () => {
             if (state.editor) {
                 state.editor.moveLayer(i, i - 1);
@@ -368,9 +370,9 @@ export function refreshLayerList(): void {
         mergeBtn.className = 'layer-item-btn';
         mergeBtn.type = 'button';
         mergeBtn.textContent = '↴';
-        mergeBtn.title = 'Merge down';
-        mergeBtn.setAttribute('aria-label', 'Merge down');
-        mergeBtn.disabled = i === 0;
+        mergeBtn.title = isBottomLayer ? 'Cannot merge the bottom layer down' : 'Merge down';
+        mergeBtn.setAttribute('aria-label', isBottomLayer ? 'Cannot merge the bottom layer down' : 'Merge down');
+        mergeBtn.disabled = isBottomLayer;
         mergeBtn.addEventListener('click', () => {
             if (state.editor) {
                 state.editor.mergeLayerDown(i);
@@ -385,9 +387,10 @@ export function refreshLayerList(): void {
         delBtn.className = 'layer-item-btn';
         delBtn.type = 'button';
         delBtn.textContent = '🗑';
-        delBtn.title = 'Delete layer';
-        delBtn.setAttribute('aria-label', 'Delete layer');
-        delBtn.disabled = count <= 1;
+        const isOnlyLayer = count <= 1;
+        delBtn.title = isOnlyLayer ? 'Cannot delete the only remaining layer' : 'Delete layer';
+        delBtn.setAttribute('aria-label', isOnlyLayer ? 'Cannot delete the only remaining layer' : 'Delete layer');
+        delBtn.disabled = isOnlyLayer;
         delBtn.addEventListener('click', () => {
             if (state.editor) {
                 if (confirm('Delete this layer? This cannot be undone.')) {
@@ -418,10 +421,30 @@ export function updateUI(): void {
         const canUndo = state.editor.can_undo;
         const canRedo = state.editor.can_redo;
 
-        if (state.undoBtn) state.undoBtn.disabled = !canUndo;
-        if (state.redoBtn) state.redoBtn.disabled = !canRedo;
-        if (state.mobileUndoBtn) state.mobileUndoBtn.disabled = !canUndo;
-        if (state.mobileRedoBtn) state.mobileRedoBtn.disabled = !canRedo;
+        if (state.undoBtn) {
+            state.undoBtn.disabled = !canUndo;
+            const title = canUndo ? 'Undo (Ctrl+Z)' : 'Nothing to undo';
+            state.undoBtn.title = title;
+            state.undoBtn.setAttribute('aria-label', title);
+        }
+        if (state.redoBtn) {
+            state.redoBtn.disabled = !canRedo;
+            const title = canRedo ? 'Redo (Ctrl+Shift+Z or Ctrl+Y)' : 'Nothing to redo';
+            state.redoBtn.title = title;
+            state.redoBtn.setAttribute('aria-label', title);
+        }
+        if (state.mobileUndoBtn) {
+            state.mobileUndoBtn.disabled = !canUndo;
+            const title = canUndo ? 'Undo' : 'Nothing to undo';
+            state.mobileUndoBtn.title = title;
+            state.mobileUndoBtn.setAttribute('aria-label', title);
+        }
+        if (state.mobileRedoBtn) {
+            state.mobileRedoBtn.disabled = !canRedo;
+            const title = canRedo ? 'Redo' : 'Nothing to redo';
+            state.mobileRedoBtn.title = title;
+            state.mobileRedoBtn.setAttribute('aria-label', title);
+        }
 
         if (state.gridSizeEl) state.gridSizeEl.textContent = `${state.editor.width} × ${state.editor.height}`;
         if (state.statusToolEl) state.statusToolEl.textContent = `Tool: ${capitalize(state.editor.tool)}`;

--- a/web/ui.ts
+++ b/web/ui.ts
@@ -257,6 +257,10 @@ export function refreshLayerList(): void {
     }
 
     for (let i = count - 1; i >= 0; i--) {
+        const isTopLayer = i === count - 1;
+        const isBottomLayer = i === 0;
+        const isOnlyLayer = count <= 1;
+
         const item = document.createElement('div');
         item.className = 'layer-item';
         if (i === active) item.classList.add('active');
@@ -336,7 +340,6 @@ export function refreshLayerList(): void {
         upBtn.className = 'layer-item-btn';
         upBtn.type = 'button';
         upBtn.textContent = '↑';
-        const isTopLayer = i === count - 1;
         upBtn.title = isTopLayer ? 'Cannot move the top layer further up' : 'Move up';
         upBtn.setAttribute('aria-label', isTopLayer ? 'Cannot move the top layer further up' : 'Move up');
         upBtn.disabled = isTopLayer;
@@ -353,7 +356,6 @@ export function refreshLayerList(): void {
         downBtn.className = 'layer-item-btn';
         downBtn.type = 'button';
         downBtn.textContent = '↓';
-        const isBottomLayer = i === 0;
         downBtn.title = isBottomLayer ? 'Cannot move the bottom layer further down' : 'Move down';
         downBtn.setAttribute('aria-label', isBottomLayer ? 'Cannot move the bottom layer further down' : 'Move down');
         downBtn.disabled = isBottomLayer;
@@ -387,7 +389,6 @@ export function refreshLayerList(): void {
         delBtn.className = 'layer-item-btn';
         delBtn.type = 'button';
         delBtn.textContent = '🗑';
-        const isOnlyLayer = count <= 1;
         delBtn.title = isOnlyLayer ? 'Cannot delete the only remaining layer' : 'Delete layer';
         delBtn.setAttribute('aria-label', isOnlyLayer ? 'Cannot delete the only remaining layer' : 'Delete layer');
         delBtn.disabled = isOnlyLayer;
@@ -423,15 +424,13 @@ export function updateUI(): void {
 
         if (state.undoBtn) {
             state.undoBtn.disabled = !canUndo;
-            const title = canUndo ? 'Undo (Ctrl+Z)' : 'Nothing to undo';
-            state.undoBtn.title = title;
-            state.undoBtn.setAttribute('aria-label', title);
+            state.undoBtn.title = canUndo ? 'Undo (Ctrl+Z)' : 'Nothing to undo';
+            state.undoBtn.setAttribute('aria-label', canUndo ? 'Undo' : 'Nothing to undo');
         }
         if (state.redoBtn) {
             state.redoBtn.disabled = !canRedo;
-            const title = canRedo ? 'Redo (Ctrl+Shift+Z or Ctrl+Y)' : 'Nothing to redo';
-            state.redoBtn.title = title;
-            state.redoBtn.setAttribute('aria-label', title);
+            state.redoBtn.title = canRedo ? 'Redo (Ctrl+Shift+Z or Ctrl+Y)' : 'Nothing to redo';
+            state.redoBtn.setAttribute('aria-label', canRedo ? 'Redo' : 'Nothing to redo');
         }
         if (state.mobileUndoBtn) {
             state.mobileUndoBtn.disabled = !canUndo;

--- a/web/ux.test.ts
+++ b/web/ux.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TOOL_INFO, updateToolButtons, setTool } from './main';
 import { state } from './state';
 import { setupEventListeners } from './events';
-import { refreshLayerList, updateUI } from './ui';
+import { refreshLayerList } from './ui';
 
 describe('UX Improvements', () => {
     beforeEach(() => {
@@ -229,99 +229,5 @@ describe('UX Improvements', () => {
         closeBtn?.dispatchEvent(new MouseEvent('click'));
         expect(sidePanel?.classList.contains('open')).toBe(false);
         expect(menuBtn?.getAttribute('aria-expanded')).toBe('false');
-    });
-
-    it('should expose descriptive labels for locked layer actions', () => {
-        const layerList = document.createElement('div');
-        layerList.id = 'layer-list';
-        document.body.appendChild(layerList);
-
-        state.editor = {
-            layerCount: 2,
-            activeLayer: 0,
-            layerName: vi.fn((i: number) => `Layer ${i + 1}`),
-            layerVisible: vi.fn().mockReturnValue(true),
-            layerLocked: vi.fn().mockReturnValue(false),
-            moveLayer: vi.fn(),
-            mergeLayerDown: vi.fn(),
-            deleteLayer: vi.fn(),
-        } as unknown as typeof state.editor;
-
-        refreshLayerList();
-
-        const items = layerList.querySelectorAll<HTMLElement>('.layer-item');
-        expect(items.length).toBe(2);
-
-        // Loop renders top-most layer first (i === count - 1).
-        const topItem = items[0];
-        const bottomItem = items[1];
-
-        const topUp = topItem.querySelector('button[aria-label="Cannot move the top layer further up"]');
-        expect(topUp).toBeTruthy();
-        expect((topUp as HTMLButtonElement).disabled).toBe(true);
-
-        const bottomDown = bottomItem.querySelector('button[aria-label="Cannot move the bottom layer further down"]');
-        const bottomMerge = bottomItem.querySelector('button[aria-label="Cannot merge the bottom layer down"]');
-        expect(bottomDown).toBeTruthy();
-        expect(bottomMerge).toBeTruthy();
-        expect((bottomDown as HTMLButtonElement).disabled).toBe(true);
-        expect((bottomMerge as HTMLButtonElement).disabled).toBe(true);
-
-        // Two layers remain, so deletion is still allowed.
-        const deleteBtn = bottomItem.querySelector('button[aria-label="Delete layer"]');
-        expect(deleteBtn).toBeTruthy();
-        expect((deleteBtn as HTMLButtonElement).disabled).toBe(false);
-    });
-
-    it('should expose the delete lock reason when only one layer remains', () => {
-        const layerList = document.createElement('div');
-        layerList.id = 'layer-list';
-        document.body.appendChild(layerList);
-
-        state.editor = {
-            layerCount: 1,
-            activeLayer: 0,
-            layerName: vi.fn().mockReturnValue('Solo layer'),
-            layerVisible: vi.fn().mockReturnValue(true),
-            layerLocked: vi.fn().mockReturnValue(false),
-            deleteLayer: vi.fn(),
-        } as unknown as typeof state.editor;
-
-        refreshLayerList();
-
-        const delBtn = layerList.querySelector<HTMLButtonElement>('button[aria-label="Cannot delete the only remaining layer"]');
-        expect(delBtn).toBeTruthy();
-        expect(delBtn?.disabled).toBe(true);
-    });
-
-    it('should update undo/redo labels to explain why they are locked', () => {
-        state.undoBtn = document.createElement('button');
-        state.redoBtn = document.createElement('button');
-        state.mobileUndoBtn = document.createElement('button');
-        state.mobileRedoBtn = document.createElement('button');
-
-        state.editor = {
-            can_undo: false,
-            can_redo: true,
-            width: 10,
-            height: 10,
-            tool: 'select',
-            layerCount: 0,
-            activeLayer: 0,
-        } as unknown as typeof state.editor;
-
-        updateUI();
-
-        expect(state.undoBtn?.disabled).toBe(true);
-        expect(state.undoBtn?.getAttribute('aria-label')).toBe('Nothing to undo');
-        expect(state.undoBtn?.title).toBe('Nothing to undo');
-
-        expect(state.redoBtn?.disabled).toBe(false);
-        expect(state.redoBtn?.getAttribute('aria-label')).toBe('Redo');
-        expect(state.redoBtn?.title).toBe('Redo (Ctrl+Shift+Z or Ctrl+Y)');
-
-        expect(state.mobileUndoBtn?.disabled).toBe(true);
-        expect(state.mobileUndoBtn?.getAttribute('aria-label')).toBe('Nothing to undo');
-        expect(state.mobileRedoBtn?.getAttribute('aria-label')).toBe('Redo');
     });
 });

--- a/web/ux.test.ts
+++ b/web/ux.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TOOL_INFO, updateToolButtons, setTool } from './main';
 import { state } from './state';
 import { setupEventListeners } from './events';
-import { refreshLayerList } from './ui';
+import { refreshLayerList, updateUI } from './ui';
 
 describe('UX Improvements', () => {
     beforeEach(() => {
@@ -229,5 +229,99 @@ describe('UX Improvements', () => {
         closeBtn?.dispatchEvent(new MouseEvent('click'));
         expect(sidePanel?.classList.contains('open')).toBe(false);
         expect(menuBtn?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should expose descriptive labels for locked layer actions', () => {
+        const layerList = document.createElement('div');
+        layerList.id = 'layer-list';
+        document.body.appendChild(layerList);
+
+        state.editor = {
+            layerCount: 2,
+            activeLayer: 0,
+            layerName: vi.fn((i: number) => `Layer ${i + 1}`),
+            layerVisible: vi.fn().mockReturnValue(true),
+            layerLocked: vi.fn().mockReturnValue(false),
+            moveLayer: vi.fn(),
+            mergeLayerDown: vi.fn(),
+            deleteLayer: vi.fn(),
+        } as unknown as typeof state.editor;
+
+        refreshLayerList();
+
+        const items = layerList.querySelectorAll<HTMLElement>('.layer-item');
+        expect(items.length).toBe(2);
+
+        // Loop renders top-most layer first (i === count - 1).
+        const topItem = items[0];
+        const bottomItem = items[1];
+
+        const topUp = topItem.querySelector('button[aria-label="Cannot move the top layer further up"]');
+        expect(topUp).toBeTruthy();
+        expect((topUp as HTMLButtonElement).disabled).toBe(true);
+
+        const bottomDown = bottomItem.querySelector('button[aria-label="Cannot move the bottom layer further down"]');
+        const bottomMerge = bottomItem.querySelector('button[aria-label="Cannot merge the bottom layer down"]');
+        expect(bottomDown).toBeTruthy();
+        expect(bottomMerge).toBeTruthy();
+        expect((bottomDown as HTMLButtonElement).disabled).toBe(true);
+        expect((bottomMerge as HTMLButtonElement).disabled).toBe(true);
+
+        // Two layers remain, so deletion is still allowed.
+        const deleteBtn = bottomItem.querySelector('button[aria-label="Delete layer"]');
+        expect(deleteBtn).toBeTruthy();
+        expect((deleteBtn as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('should expose the delete lock reason when only one layer remains', () => {
+        const layerList = document.createElement('div');
+        layerList.id = 'layer-list';
+        document.body.appendChild(layerList);
+
+        state.editor = {
+            layerCount: 1,
+            activeLayer: 0,
+            layerName: vi.fn().mockReturnValue('Solo layer'),
+            layerVisible: vi.fn().mockReturnValue(true),
+            layerLocked: vi.fn().mockReturnValue(false),
+            deleteLayer: vi.fn(),
+        } as unknown as typeof state.editor;
+
+        refreshLayerList();
+
+        const delBtn = layerList.querySelector<HTMLButtonElement>('button[aria-label="Cannot delete the only remaining layer"]');
+        expect(delBtn).toBeTruthy();
+        expect(delBtn?.disabled).toBe(true);
+    });
+
+    it('should update undo/redo labels to explain why they are locked', () => {
+        state.undoBtn = document.createElement('button');
+        state.redoBtn = document.createElement('button');
+        state.mobileUndoBtn = document.createElement('button');
+        state.mobileRedoBtn = document.createElement('button');
+
+        state.editor = {
+            can_undo: false,
+            can_redo: true,
+            width: 10,
+            height: 10,
+            tool: 'select',
+            layerCount: 0,
+            activeLayer: 0,
+        } as unknown as typeof state.editor;
+
+        updateUI();
+
+        expect(state.undoBtn?.disabled).toBe(true);
+        expect(state.undoBtn?.getAttribute('aria-label')).toBe('Nothing to undo');
+        expect(state.undoBtn?.title).toBe('Nothing to undo');
+
+        expect(state.redoBtn?.disabled).toBe(false);
+        expect(state.redoBtn?.getAttribute('aria-label')).toBe('Redo');
+        expect(state.redoBtn?.title).toBe('Redo (Ctrl+Shift+Z or Ctrl+Y)');
+
+        expect(state.mobileUndoBtn?.disabled).toBe(true);
+        expect(state.mobileUndoBtn?.getAttribute('aria-label')).toBe('Nothing to undo');
+        expect(state.mobileRedoBtn?.getAttribute('aria-label')).toBe('Redo');
     });
 });


### PR DESCRIPTION
This change introduces micro-UX and accessibility improvements to the ASCII editor UI. Action-buttons whose states switch dynamically (including the Undo, Redo, and dynamic layer list items such as Move up, Move down, Merge down, and Delete layer) now dynamically configure highly descriptive tooltips (via the title attribute) and matching ARIA labels explaining why they are locked or what shortcut they execute.

---
*PR created automatically by Jules for task [9676380765521363542](https://jules.google.com/task/9676380765521363542) started by @d-o-hub*