### PR TITLE
feat(clipboard): export fidelity controls and pure ASCII fallback (#176)

### DIFF
--- a/e2e/clipboard.spec.ts
+++ b/e2e/clipboard.spec.ts
@@ -11,6 +11,11 @@ declare global {
         editor: {
             exportAscii(): string;
             exportForCopy?: () => string;
+            exportForCopyWithOptions?: (
+                trimTrailingWhitespace: boolean,
+                enforceBoundingBox: boolean,
+                convertUnicodeToAscii: boolean,
+            ) => string;
             serializeDocument(): string;
             loadDocument(json: string): boolean;
             clear(): void;
@@ -87,6 +92,24 @@ test.describe('Copy / export fidelity', () => {
         });
 
         expect(forCopy).toBe(full);
+    });
+
+    test('exportForCopyWithOptions provides a pure ASCII fallback', async ({ page }) => {
+        await page.click('[data-tool="rectangle"]');
+        const canvas = page.locator('#canvas');
+        const box = await canvas.boundingBox();
+        if (!box) return;
+
+        await page.mouse.move(box.x + 50, box.y + 50);
+        await page.mouse.down();
+        await page.mouse.move(box.x + 120, box.y + 90);
+        await page.mouse.up();
+        await page.waitForFunction(() => (window.editor?.exportAscii() ?? '').length > 0);
+
+        const ascii = await page.evaluate(() => window.editor?.exportForCopyWithOptions?.(false, true, true) ?? '');
+        expect(ascii.length).toBeGreaterThan(0);
+        expect([...ascii].every((char) => char === '\\n' || char === '\\r' || char.charCodeAt(0) < 128)).toBeTruthy();
+        expect(ascii).toMatch(/[+\\-|]/);
     });
 
     test('copy button shows toast', async ({ page, isMobile }) => {

--- a/plans/ADRs/041-clipboard-export-modes.md
+++ b/plans/ADRs/041-clipboard-export-modes.md
@@ -1,0 +1,38 @@
+# ADR-041: Configurable Clipboard Export Fidelity
+
+## Status
+Accepted
+
+## Context
+
+Issue #176 reports that copying box-drawing diagrams into external editors can lose
+right borders when trailing spaces are removed, and that Unicode box glyphs can
+render inconsistently in Windows Notepad and other non-monospace environments.
+Clipboard writes also need to work when the asynchronous Clipboard API is blocked
+by permissions, an insecure context, or an iframe policy.
+
+## Decision
+
+Keep the core exporter as the source of truth and add additive export options for:
+
+- preserving rectangular line widths by default,
+- optionally trimming trailing whitespace when rectangular preservation is disabled,
+- converting supported drawing glyphs to a 7-bit ASCII fallback.
+
+Expose an additive WASM export method for callers that need explicit Rust-side
+options. The web copy path mirrors those options for event-generated exports and
+presents them as a Copy Format selector plus a rectangular-width checkbox. Normalize
+all resulting text to CRLF, attempt `navigator.clipboard.writeText`, and fall back
+to a temporary textarea with `document.execCommand('copy')` when the modern API
+cannot be used.
+
+## Consequences
+
+- Existing Unicode copy behavior remains the default and existing export APIs stay
+  source-compatible for callers using `Default` or the existing functions.
+- Pure ASCII mode intentionally replaces unsupported non-ASCII glyphs with `?` so
+  the requested mode is guaranteed to remain 7-bit.
+- Rectangular exports may contain trailing spaces; this is deliberate because those
+  spaces preserve columns in external editors.
+- The legacy fallback is synchronous internally and is used only after the modern
+  API is unavailable or rejects the write.

--- a/src/core/ascii_export.rs
+++ b/src/core/ascii_export.rs
@@ -11,6 +11,12 @@ pub struct ExportOptions {
     pub line_numbers: bool,
     /// Maximum width (0 = no limit)
     pub max_width: usize,
+    /// Remove spaces at the end of each exported line when the bounding box is not enforced.
+    pub trim_trailing_whitespace: bool,
+    /// Keep every exported line padded to the selected rectangular width.
+    pub enforce_bounding_box: bool,
+    /// Convert box-drawing and other supported Unicode glyphs to 7-bit ASCII.
+    pub convert_unicode_to_ascii: bool,
 }
 
 impl Default for ExportOptions {
@@ -19,6 +25,9 @@ impl Default for ExportOptions {
             trim_borders: true,
             line_numbers: false,
             max_width: 0,
+            trim_trailing_whitespace: false,
+            enforce_bounding_box: true,
+            convert_unicode_to_ascii: false,
         }
     }
 }
@@ -71,45 +80,50 @@ fn export_in_bounds(
     max_x: i32,
     max_y: i32,
 ) -> String {
-    // Calculate approximate capacity
+    // Width is measured in grid columns, not UTF-8 bytes.
     let width = (max_x - min_x + 1).max(0) as usize;
     let height = (max_y - min_y + 1).max(0) as usize;
-
-    let mut line_prefix_len = 0;
-    if options.line_numbers {
-        line_prefix_len = 7; // Estimated: " 1234 | "
-    }
-
-    let cols = width.min(if options.max_width > 0 {
+    let prefix_width = if options.line_numbers { 7 } else { 0 };
+    let max_line_width = if options.max_width > 0 {
         options.max_width
     } else {
         usize::MAX
-    });
-    let mut result = String::with_capacity(height * (line_prefix_len + cols + 1));
+    };
+    let mut result = String::with_capacity(height * (prefix_width + width + 1));
 
     for y in min_y..=max_y {
-        let mut line_chars_count = 0;
+        let mut line = String::new();
 
         if options.line_numbers {
-            let prefix = format!("{:4} | ", y + 1);
-            for ch in prefix.chars() {
-                if options.max_width > 0 && line_chars_count >= options.max_width {
+            for ch in format!("{:4} | ", y + 1).chars() {
+                if line.chars().count() >= max_line_width {
                     break;
                 }
-                result.push(ch);
-                line_chars_count += 1;
+                line.push(ch);
             }
         }
 
         for x in min_x..=max_x {
-            if options.max_width > 0 && line_chars_count >= options.max_width {
+            if line.chars().count() >= max_line_width {
                 break;
             }
             let ch = grid.get(x, y).map(|c| c.ch).unwrap_or(' ');
-            result.push(ch);
-            line_chars_count += 1;
+            line.push(if options.convert_unicode_to_ascii {
+                ascii_fallback_char(ch)
+            } else {
+                ch
+            });
         }
 
+        // A rectangular export deliberately retains trailing spaces. Trimming is only
+        // meaningful when callers opt out of the geometry guarantee.
+        if options.trim_trailing_whitespace && !options.enforce_bounding_box {
+            while line.ends_with(' ') {
+                line.pop();
+            }
+        }
+
+        result.push_str(&line);
         if y < max_y {
             result.push('\n');
         }
@@ -141,34 +155,56 @@ pub fn find_content_bounds(grid: &Grid) -> Option<(i32, i32, i32, i32)> {
     }
 }
 
-/// Export a rectangular region of the grid.
+/// Export a rectangular region of the grid using the default fidelity options.
 pub fn export_region(grid: &Grid, x1: i32, y1: i32, x2: i32, y2: i32) -> String {
+    export_region_with_options(grid, x1, y1, x2, y2, &ExportOptions::default())
+}
+
+/// Export a rectangular region of the grid with explicit fidelity options.
+pub fn export_region_with_options(
+    grid: &Grid,
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+    options: &ExportOptions,
+) -> String {
     let min_x = x1.min(x2);
     let min_y = y1.min(y2);
     let max_x = x1.max(x2);
     let max_y = y1.max(y2);
 
-    // If the region is entirely outside the grid, return empty string or empty grid shape?
-    // Current behavior for export_trimmed/full is to return content.
-    // For a specific region request, we should probably return the requested size,
-    // but clamped to grid boundaries for actual content.
-    // Actually, export_region is often used for copy-paste where we want exactly the region.
+    export_in_bounds(grid, options, min_x, min_y, max_x, max_y)
+}
 
-    let mut result = String::with_capacity(
-        ((max_y - min_y + 1).max(0) as usize) * ((max_x - min_x + 1).max(0) as usize + 1),
-    );
-
-    for y in min_y..=max_y {
-        for x in min_x..=max_x {
-            let ch = grid.get(x, y).map(|c| c.ch).unwrap_or(' ');
-            result.push(ch);
+/// Convert a supported Unicode drawing glyph to its 7-bit ASCII equivalent.
+///
+/// Box corners and junctions become `+`, horizontal strokes become `-`, and
+/// vertical strokes become `|`. Other non-ASCII glyphs become `?` so callers
+/// requesting a pure ASCII export receive only 7-bit characters.
+pub fn ascii_fallback_char(ch: char) -> char {
+    match ch {
+        '─' | '━' | '═' | '╌' | '╍' | '┄' | '┅' | '┈' | '┉' | '╴' | '╶' | '╸' | '╺' => {
+            '-'
         }
-        if y < max_y {
-            result.push('\n');
+        '│' | '┃' | '║' | '┆' | '┇' | '┊' | '┋' | '╎' | '╏' | '╵' | '╷' | '╹' | '╻' => {
+            '|'
         }
+        '┌' | '┐' | '└' | '┘' | '┏' | '┓' | '┗' | '┛' | '╔' | '╗' | '╚' | '╝' | '╭' | '╮' | '╰'
+        | '╯' | '┼' | '╋' | '╬' | '╁' | '╂' | '╃' | '╄' | '╅' | '╆' | '╇' | '╈' | '╉' | '╊'
+        | '╳' | '┬' | '┴' | '├' | '┤' | '╞' | '╡' | '╥' | '╨' | '╪' | '╫' | '╀' => {
+            '+'
+        }
+        '╱' => '/',
+        '╲' => '\\',
+        '◆' | '◇' | '●' | '•' | '·' => '*',
+        '▲' | '△' => '^',
+        '▼' | '▽' => 'v',
+        '◀' | '◁' => '<',
+        '▶' | '▷' => '>',
+        ch if ch.is_ascii() => ch,
+        _ => '?',
     }
-
-    result
 }
 
 /// Count non-empty cells in the grid.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,7 +17,9 @@ pub mod selection;
 pub mod tools;
 
 // Re-exports
-pub use ascii_export::{export_grid, ExportOptions};
+pub use ascii_export::{
+    ascii_fallback_char, export_grid, export_region, export_region_with_options, ExportOptions,
+};
 pub use cell::{Cell, CellStyle};
 pub use commands::Command;
 pub use grid::Grid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,9 @@ pub mod wasm;
 
 // Re-exports for convenience
 pub use core::{
-    export_grid, BorderStyle, Cell, CellStyle, Command, DrawOp, EditorState, ExportOptions, Grid,
-    History, Selection, Tool, ToolId, ToolResult,
+    ascii_fallback_char, export_grid, export_region, export_region_with_options, BorderStyle, Cell,
+    CellStyle, Command, DrawOp, EditorState, ExportOptions, Grid, History, Selection, Tool, ToolId,
+    ToolResult,
 };
 pub use render::{CanvasRenderer, DirtyRect, FontMetrics};
 pub use ui::{ShortcutManager, Theme, ToolbarConfig};

--- a/src/wasm/helpers.rs
+++ b/src/wasm/helpers.rs
@@ -1,12 +1,12 @@
 //! Private helper methods for AsciiEditor.
 
-use crate::core::ascii_export::export_region;
+use crate::core::ascii_export::{export_grid, export_region_with_options, ExportOptions};
 use crate::core::commands::{Command, DrawCommand};
 use crate::core::history::{History, DEFAULT_MAX_DEPTH};
 use crate::core::selection::{Selection, SelectionClipboard};
 use crate::core::tools::{DrawOp, SelectTool, ToolContext, ToolId};
 use crate::wasm::render_bridge::{
-    create_event_result, create_event_result_with_copy, export_ascii, EditorEventResult,
+    create_event_result, create_event_result_with_copy, EditorEventResult,
 };
 
 use super::bindings::AsciiEditor;
@@ -23,12 +23,17 @@ impl AsciiEditor {
     /// Export text for OS clipboard: selection region if present, else full composite.
     /// Always reads from the composite of visible layers so multi-layer docs match `exportAscii`.
     pub(crate) fn export_for_copy(&self) -> String {
+        self.export_for_copy_with_options(&ExportOptions::default())
+    }
+
+    /// Export the current copy scope with explicit clipboard fidelity options.
+    pub(crate) fn export_for_copy_with_options(&self, options: &ExportOptions) -> String {
         let composite = self.composite_visible_grid();
         if let Some(ref sel) = self.current_selection {
             let (min_x, min_y, max_x, max_y) = sel.bounds();
-            export_region(&composite, min_x, min_y, max_x, max_y)
+            export_region_with_options(&composite, min_x, min_y, max_x, max_y, options)
         } else {
-            export_ascii(&composite)
+            export_grid(&composite, options)
         }
     }
 

--- a/src/wasm/render_api.rs
+++ b/src/wasm/render_api.rs
@@ -3,6 +3,7 @@
 use wasm_bindgen::prelude::*;
 
 use super::bindings::AsciiEditor;
+use crate::core::ascii_export::ExportOptions;
 use crate::wasm::render_bridge::{
     export_ascii, get_dirty_render_commands, get_render_commands, get_render_commands_full,
     needs_redraw, request_full_redraw,
@@ -78,6 +79,25 @@ impl AsciiEditor {
     #[wasm_bindgen(js_name = exportForCopy)]
     pub fn export_for_copy_public(&self) -> String {
         self.export_for_copy()
+    }
+
+    /// Export the copy scope with explicit whitespace and character-fidelity options.
+    #[wasm_bindgen(js_name = exportForCopyWithOptions)]
+    pub fn export_for_copy_with_options_public(
+        &self,
+        trim_trailing_whitespace: bool,
+        enforce_bounding_box: bool,
+        convert_unicode_to_ascii: bool,
+    ) -> String {
+        let options = ExportOptions {
+            trim_borders: true,
+            line_numbers: false,
+            max_width: 0,
+            trim_trailing_whitespace,
+            enforce_bounding_box,
+            convert_unicode_to_ascii,
+        };
+        self.export_for_copy_with_options(&options)
     }
 
     /// Serialize diagram to JSON (`.asc` format).

--- a/tests/core/export.rs
+++ b/tests/core/export.rs
@@ -1,7 +1,8 @@
 //! ASCII export tests.
 
 use ascii_canvas::core::ascii_export::{
-    count_content, export_grid, export_region, find_content_bounds, ExportOptions,
+    ascii_fallback_char, count_content, export_grid, export_region, find_content_bounds,
+    ExportOptions,
 };
 use ascii_canvas::core::grid::Grid;
 
@@ -86,6 +87,61 @@ fn test_export_region() {
     assert!(result.contains('B'));
     assert!(result.contains('C'));
     assert!(result.contains('D'));
+}
+
+#[test]
+fn test_copy_options_preserve_rectangular_box_and_unicode() {
+    let mut grid = Grid::new(12, 4);
+    grid.set_char(0, 0, '┌');
+    grid.set_char(1, 0, '─');
+    grid.set_char(2, 0, '┐');
+    grid.set_char(0, 1, '│');
+    grid.set_char(2, 1, '│');
+    grid.set_char(0, 2, '└');
+    grid.set_char(1, 2, '─');
+    grid.set_char(2, 2, '┘');
+    grid.set_char(10, 0, 'B');
+
+    let result = export_grid(&grid, &ExportOptions::default());
+    let widths: Vec<usize> = result.lines().map(|line| line.chars().count()).collect();
+    assert_eq!(widths, vec![11, 11, 11]);
+    assert_eq!(result.lines().nth(1), Some("│ │        "));
+
+    let ascii = export_grid(
+        &grid,
+        &ExportOptions {
+            convert_unicode_to_ascii: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(ascii.lines().next(), Some("+-+       B"));
+    assert!(ascii.chars().all(|ch| ch.is_ascii() || ch == '\n'));
+}
+
+#[test]
+fn test_copy_options_can_trim_trailing_whitespace() {
+    let mut grid = Grid::new(4, 2);
+    grid.set_char(0, 0, 'A');
+    grid.set_char(2, 1, 'B');
+
+    let result = export_grid(
+        &grid,
+        &ExportOptions {
+            trim_trailing_whitespace: true,
+            enforce_bounding_box: false,
+            ..Default::default()
+        },
+    );
+    assert_eq!(result, "A\n  B");
+}
+
+#[test]
+fn test_ascii_fallback_maps_box_drawing_glyphs() {
+    assert_eq!(ascii_fallback_char('│'), '|');
+    assert_eq!(ascii_fallback_char('─'), '-');
+    assert_eq!(ascii_fallback_char('┌'), '+');
+    assert_eq!(ascii_fallback_char('┘'), '+');
+    assert_eq!(ascii_fallback_char('🦀'), '?');
 }
 
 #[test]

--- a/web/clipboard.test.ts
+++ b/web/clipboard.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+    copyAsciiToClipboard,
+    formatClipboardText,
+    writeTextToClipboard,
+} from './clipboard.js';
 import { normalizeToCRLF } from './utils.js';
+
+const preserveWidth: Parameters<typeof formatClipboardText>[1] = {
+    convertUnicodeToAscii: false,
+    enforceBoundingBox: true,
+};
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 describe('normalizeToCRLF', () => {
     it('converts LF-only to CRLF', () => {
@@ -12,6 +26,10 @@ describe('normalizeToCRLF', () => {
 
     it('handles mixed line endings correctly', () => {
         expect(normalizeToCRLF('a\r\nb\nc\r\nd')).toBe('a\r\nb\r\nc\r\nd');
+    });
+
+    it('normalizes lone carriage returns to CRLF too', () => {
+        expect(normalizeToCRLF('a\rb\n\r\nc')).toBe('a\r\nb\r\n\r\nc');
     });
 
     it('preserves empty string', () => {
@@ -30,5 +48,69 @@ describe('normalizeToCRLF', () => {
         expect(lines[0]).toBe('┌───┐');
         expect(lines[1]).toBe('│   │');
         expect(lines[2]).toBe('└───┘');
+    });
+});
+
+describe('clipboard formatting and fallback', () => {
+    it('keeps spaced diagram rows rectangular', () => {
+        const text = ' [foo] ---> [bar]  \n       |           |';
+        const result = formatClipboardText(text, preserveWidth);
+        const lines = result.split('\r\n');
+
+        expect(lines).toHaveLength(2);
+        expect(lines[0]).toHaveLength(lines[1].length);
+        expect(lines[0].endsWith('  ')).toBe(true);
+    });
+
+    it('converts box drawing to pure ASCII without changing columns', () => {
+        const result = formatClipboardText('┌──┐\n│  │\n└──┘', {
+            convertUnicodeToAscii: true,
+            enforceBoundingBox: true,
+        });
+
+        expect(result).toBe('+--+\r\n|  |\r\n+--+');
+        expect([...result].every((char) => char === '\r' || char === '\n' || char.charCodeAt(0) < 128)).toBe(true);
+    });
+
+    it('trims trailing spaces only when rectangular preservation is disabled', () => {
+        const result = formatClipboardText('A  \n B ', {
+            convertUnicodeToAscii: false,
+            enforceBoundingBox: false,
+        });
+
+        expect(result).toBe('A\r\n B');
+    });
+
+    it('uses execCommand when the Clipboard API is rejected', async () => {
+        const writeText = vi.fn().mockRejectedValue(new Error('permission denied'));
+        vi.stubGlobal('navigator', { clipboard: { writeText } });
+        const execCommand = vi.fn().mockReturnValue(true);
+        Object.defineProperty(document, 'execCommand', {
+            configurable: true,
+            value: execCommand,
+        });
+
+        await writeTextToClipboard('copy me');
+
+        expect(writeText).toHaveBeenCalledWith('copy me');
+        expect(execCommand).toHaveBeenCalledWith('copy');
+    });
+
+    it('reports copy success after the fallback path', async () => {
+        vi.stubGlobal('navigator', { clipboard: undefined });
+        const execCommand = vi.fn().mockReturnValue(true);
+        Object.defineProperty(document, 'execCommand', {
+            configurable: true,
+            value: execCommand,
+        });
+        const toast = vi.fn();
+
+        await copyAsciiToClipboard('┌─┐', toast, {
+            convertUnicodeToAscii: true,
+            enforceBoundingBox: true,
+        });
+
+        expect(execCommand).toHaveBeenCalledWith('copy');
+        expect(toast).toHaveBeenCalledWith('Copied as pure ASCII');
     });
 });

--- a/web/clipboard.ts
+++ b/web/clipboard.ts
@@ -8,30 +8,153 @@ import type { AsciiEditor } from './types.js';
 
 export type ToastFn = (message: string, isError?: boolean) => void;
 
+export interface ClipboardOptions {
+    /** Convert drawing glyphs to a 7-bit ASCII representation. */
+    convertUnicodeToAscii: boolean;
+    /** Keep each exported line at its rectangular width, including trailing spaces. */
+    enforceBoundingBox: boolean;
+}
+
+export const DEFAULT_CLIPBOARD_OPTIONS: ClipboardOptions = {
+    convertUnicodeToAscii: false,
+    enforceBoundingBox: true,
+};
+
+/** Read the copy controls, falling back to fidelity-preserving defaults in tests or embeds. */
+export function getClipboardOptions(): ClipboardOptions {
+    if (typeof document === 'undefined') {
+        return { ...DEFAULT_CLIPBOARD_OPTIONS };
+    }
+
+    const format = document.querySelector<HTMLSelectElement>('#copy-format')?.value;
+    const preserveWidth = document.querySelector<HTMLInputElement>('#copy-bounding-box')?.checked;
+    return {
+        convertUnicodeToAscii: format === 'ascii',
+        enforceBoundingBox: preserveWidth ?? DEFAULT_CLIPBOARD_OPTIONS.enforceBoundingBox,
+    };
+}
+
+function asciiFallbackChar(char: string): string {
+    switch (char) {
+        case '─': case '━': case '═': case '╌': case '╍': case '┄': case '┅': case '┈': case '┉':
+        case '╴': case '╶': case '╸': case '╺':
+            return '-';
+        case '│': case '┃': case '║': case '┆': case '┇': case '┊': case '┋': case '╎': case '╏':
+        case '╵': case '╷': case '╹': case '╻':
+            return '|';
+        case '┌': case '┐': case '└': case '┘': case '┏': case '┓': case '┗': case '┛':
+        case '╔': case '╗': case '╚': case '╝': case '╭': case '╮': case '╰': case '╯':
+        case '┼': case '╋': case '╬': case '╁': case '╂': case '╃': case '╄': case '╅': case '╆':
+        case '╇': case '╈': case '╉': case '╊': case '╳': case '┬': case '┴': case '├': case '┤':
+        case '╞': case '╡': case '╥': case '╨': case '╪': case '╫': case '╀':
+            return '+';
+        case '╱': return '/';
+        case '╲': return '\\';
+        case '◆': case '◇': case '●': case '•': case '·': return '*';
+        case '▲': case '△': return '^';
+        case '▼': case '▽': return 'v';
+        case '◀': case '◁': return '<';
+        case '▶': case '▷': return '>';
+        default: return char.codePointAt(0)! < 128 ? char : '?';
+    }
+}
+
+/** Apply the selected representation while retaining logical line boundaries. */
+export function formatClipboardText(text: string, options: ClipboardOptions): string {
+    const lines = text.split(/\r?\n/u).map((line) => options.convertUnicodeToAscii
+        ? Array.from(line, asciiFallbackChar).join('')
+        : line);
+
+    if (options.enforceBoundingBox) {
+        const width = Math.max(0, ...lines.map((line) => Array.from(line).length));
+        return normalizeToCRLF(lines.map((line) => {
+            const padding = width - Array.from(line).length;
+            return `${line}${' '.repeat(padding)}`;
+        }).join('\n'));
+    }
+
+    return normalizeToCRLF(lines.map((line) => line.replace(/[ \t]+$/u, '')).join('\n'));
+}
+
 /**
- * Copy ASCII to the system clipboard with CRLF line endings.
- *
- * Uses plain text only (not text/html) so external paste targets receive the same
- * characters without Codacy/eslint-plugin-xss false positives on HTML clipboard MIME.
+ * Copy text through the modern Clipboard API, falling back to a temporary textarea
+ * for insecure, permission-restricted, or embedded browser contexts.
  */
-export async function copyAsciiToClipboard(text: string, showToast: ToastFn): Promise<void> {
-    const normalized = normalizeToCRLF(text);
+export async function writeTextToClipboard(text: string): Promise<void> {
+    let clipboardError: unknown = new Error('Clipboard API unavailable');
 
     try {
-        await navigator.clipboard.writeText(normalized);
-        showToast('Copied — paste in a monospace editor');
+        if (typeof navigator !== 'undefined'
+            && navigator.clipboard
+            && typeof navigator.clipboard.writeText === 'function') {
+            await navigator.clipboard.writeText(text);
+            return;
+        }
+    } catch (error) {
+        clipboardError = error;
+    }
+
+    if (copyTextWithExecCommand(text)) {
+        return;
+    }
+
+    if (clipboardError instanceof Error) {
+        throw clipboardError;
+    }
+    throw new Error('Unable to copy text to the clipboard');
+}
+
+/** Attempt the legacy synchronous copy path. */
+export function copyTextWithExecCommand(text: string): boolean {
+    if (typeof document === 'undefined' || typeof document.execCommand !== 'function') {
+        return false;
+    }
+
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.setAttribute('readonly', '');
+    textArea.setAttribute('aria-hidden', 'true');
+    textArea.style.position = 'fixed';
+    textArea.style.opacity = '0';
+    textArea.style.pointerEvents = 'none';
+
+    const parent = document.body ?? document.documentElement;
+    parent.appendChild(textArea);
+    try {
+        textArea.focus();
+        textArea.select();
+        return document.execCommand('copy');
+    } catch {
+        return false;
+    } finally {
+        textArea.remove();
+    }
+}
+
+/** Copy ASCII to the system clipboard with CRLF line endings. */
+export async function copyAsciiToClipboard(
+    text: string,
+    showToast: ToastFn,
+    options: ClipboardOptions = getClipboardOptions(),
+): Promise<void> {
+    const normalized = formatClipboardText(text, options);
+
+    try {
+        await writeTextToClipboard(normalized);
+        showToast(options.convertUnicodeToAscii
+            ? 'Copied as pure ASCII'
+            : 'Copied — paste in a monospace editor');
     } catch (err) {
         logger.error('Failed to copy:', err);
         showToast('Failed to copy', true);
     }
 }
 
-/**
- * Selection-aware copy: fills internal clipboard and writes OS clipboard text.
- */
+/** Selection-aware copy: fills internal clipboard and writes OS clipboard text. */
 export async function copyToClipboard(
     editor: AsciiEditor,
     showToast: ToastFn,
+    options: ClipboardOptions = getClipboardOptions(),
 ): Promise<void> {
     // Populate internal SelectionClipboard for Ctrl+V paste inside the editor.
     if (typeof editor.copySelection === 'function') {
@@ -45,5 +168,5 @@ export async function copyToClipboard(
         ascii = editor.exportAscii();
     }
 
-    await copyAsciiToClipboard(ascii, showToast);
+    await copyAsciiToClipboard(ascii, showToast, options);
 }

--- a/web/events.ts
+++ b/web/events.ts
@@ -9,7 +9,11 @@ import {
     MIN_COLS,
     MIN_ROWS,
 } from './constants.js';
-import { copyAsciiToClipboard, copyToClipboard as copySelectionAware } from './clipboard.js';
+import {
+    copyAsciiToClipboard,
+    copyToClipboard as copySelectionAware,
+    getClipboardOptions,
+} from './clipboard.js';
 import { createAutoSaveScheduler, downloadDocument, openDocumentPicker } from './persistence.js';
 import { exportPng } from './exportPng.js';
 import { exportSvg } from './exportSvg.js';
@@ -333,7 +337,7 @@ export function handleEventResult(result: EventResult | null, options: { persist
     }
 
     if (result.should_copy && result.ascii) {
-        void copyAsciiToClipboard(result.ascii, showToast);
+        void copyAsciiToClipboard(result.ascii, showToast, getClipboardOptions());
     }
 
     updateUI();
@@ -345,7 +349,7 @@ export function handleEventResult(result: EventResult | null, options: { persist
 
 export async function copyToClipboard(): Promise<void> {
     if (!state.editor) return;
-    await copySelectionAware(state.editor, showToast);
+    await copySelectionAware(state.editor, showToast, getClipboardOptions());
 }
 
 export function applyCustomGridSize(): void {

--- a/web/index.html
+++ b/web/index.html
@@ -257,6 +257,22 @@
                     </div>
                 </section>
 
+                <!-- Copy Format -->
+                <section class="panel-section" aria-labelledby="copy-format-title">
+                    <h3 class="section-title" id="copy-format-title">Copy Format</h3>
+                    <label class="copy-option" for="copy-format">
+                        <span>Characters</span>
+                        <select id="copy-format" class="select-input" aria-label="Copy character format">
+                            <option value="unicode">Unicode UTF-8</option>
+                            <option value="ascii">Pure ASCII (7-bit)</option>
+                        </select>
+                    </label>
+                    <label class="copy-option copy-checkbox" for="copy-bounding-box">
+                        <input id="copy-bounding-box" type="checkbox" checked>
+                        <span>Preserve rectangular width</span>
+                    </label>
+                </section>
+
                 <!-- Layers -->
                 <section class="panel-section" aria-labelledby="layers-title">
                     <h3 class="section-title" id="layers-title">Layers</h3>

--- a/web/style.css
+++ b/web/style.css
@@ -456,6 +456,31 @@ body {
     outline-offset: 1px;
 }
 
+/* Copy format controls */
+.copy-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    color: var(--muted);
+    font-size: 11px;
+    margin-bottom: var(--spacing-sm);
+}
+
+.copy-option .select-input {
+    min-width: 112px;
+    max-width: 132px;
+}
+
+.copy-checkbox {
+    justify-content: flex-start;
+    cursor: pointer;
+}
+
+.copy-checkbox input {
+    accent-color: var(--accent);
+}
+
 /* Layer list styles */
 .layer-list {
     display: flex;

--- a/web/utils.ts
+++ b/web/utils.ts
@@ -4,7 +4,7 @@
 
 /** Normalize line endings to CRLF for cross-platform external paste (esp. Windows Notepad). */
 export function normalizeToCRLF(text: string): string {
-    return text.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n');
+    return text.replace(/\r\n|\r|\n/g, '\n').replace(/\n/g, '\r\n');
 }
 
 /** Capitalize the first letter of a string. */


### PR DESCRIPTION
## Summary

Addresses #176: copying ASCII diagrams into external editors (Windows Notepad) distorts box borders when trailing spaces are stripped, and Unicode box glyphs can render inconsistently. This PR adds export fidelity controls and a pure-ASCII fallback with a clipboard fallback path.

## Changes made

- **Core (`src/core/ascii_export.rs`)**: additive `ExportOptions` fields (`trim_trailing_whitespace`, `enforce_bounding_box`, `convert_unicode_to_ascii`) with default `enforce_bounding_box: true`; a Unicode→7-bit box-drawing fallback map (`│`→`|`, `─`→`-`, corners/junctions→`+`, arrows, diamonds); public `export_region_with_options`.
- **WASM (`src/wasm/render_api.rs`, `helpers.rs`)**: `exportForCopyWithOptions(trimTrailingWhitespace, enforceBoundingBox, convertUnicodeToAscii)` binding; copy scope honors options for both selection and full-composite exports.
- **Web (`web/clipboard.ts`, `utils.ts`, `events.ts`, `index.html`, `style.css`)**: Copy Format selector (Unicode UTF-8 vs Pure ASCII 7-bit) + "Preserve rectangular width" checkbox; strict CRLF normalization (handles lone `\r` too); `navigator.clipboard.writeText` with `document.execCommand('copy')` textarea fallback for restricted/permission-blocked contexts.
- **Tests**: Rust unit tests (box geometry, unicode→ascii, trim), Vitest (rectangular columns, CRLF, ASCII fallback, execCommand fallback), and a Playwright regression for `exportForCopyWithOptions`.
- **ADR-041** documents the fidelity/compatibility tradeoffs.

## Testing (harness)

- [x] Fast gates: `npm run gate:fast` (fmt, clippy, tests, architecture, web lint/tsc/vitest)
- [x] Full gates (if product behaviour): `npm run gate:full` (WASM, size, E2E)
- [x] Or equivalent CI jobs green

Locally verified: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all`, `cargo test --all --target wasm32-unknown-unknown`, WASM build + size (202 KB), web ESLint/tsc/Vitest (24 tests), and Playwright Chromium (79 tests).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] Architecture layers respected (`core` pure; see `agents-docs/architecture.md`)
- [x] Documentation / ADR updated if decision or harness changed
- [x] Tests prove the fix or feature (no weakened assertions)
- [x] If a recurring agent/CI failure was fixed: guide or sensor improved

## Related issues

Closes #176